### PR TITLE
Remove some libkb dependencies

### DIFF
--- a/update_checker_test.go
+++ b/update_checker_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol"
 	"golang.org/x/net/context"
@@ -47,7 +46,7 @@ func (u testUpdateCheckUI) UpdateQuit(_ context.Context, _ keybase1.UpdateQuitAr
 	return keybase1.UpdateQuitRes{Quit: false}, nil
 }
 
-func (u testUpdateCheckUI) GetUpdateUI() (libkb.UpdateUI, error) {
+func (u testUpdateCheckUI) GetUpdateUI() (UpdateUI, error) {
 	return u, nil
 }
 

--- a/updater_test.go
+++ b/updater_test.go
@@ -39,7 +39,7 @@ func (u testUpdateUI) UpdateQuit(_ context.Context, _ keybase1.UpdateQuitArg) (k
 	return keybase1.UpdateQuitRes{Quit: false}, nil
 }
 
-func (u testUpdateUI) GetUpdateUI() (libkb.UpdateUI, error) {
+func (u testUpdateUI) GetUpdateUI() (UpdateUI, error) {
 	return u, nil
 }
 
@@ -153,6 +153,10 @@ func (c testConfig) GetRunModeAsString() string {
 
 func (c testConfig) GetMountDir() string {
 	return filepath.Join(os.Getenv("HOME"), "keybase.test")
+}
+
+func (c testConfig) GetUpdateDefaultInstructions() (string, error) {
+	return "", nil
 }
 
 func NewDefaultTestUpdateConfig() keybase1.UpdateOptions {


### PR DESCRIPTION
Removes some libkb dependencies that aren't necessary.

The remaining dependencies are utility methods:
- DiscardAndCloseBody
- Digest
- DigestForFileAtPath
- MakeParentDirs
- PermFile
- JoinPredicate

I was thinking of creating a package github.com/keybase/client/go/util with these methods?
Or I could copy them into this repo in a utils.go file?