### PR TITLE
Keybase api (source) doesn't return status object

### DIFF
--- a/keybase/source.go
+++ b/keybase/source.go
@@ -16,18 +16,6 @@ import (
 	"github.com/keybase/go-updater/util"
 )
 
-type responseStatus struct {
-	Code   int               `json:"code"`
-	Name   string            `json:"name"`
-	Desc   string            `json:"desc"`
-	Fields map[string]string `json:"fields"`
-}
-
-type updateResponse struct {
-	Status responseStatus `json:"status"`
-	Update updater.Update `json:"update"`
-}
-
 // UpdateSource finds releases/updates on keybase.io
 type UpdateSource struct {
 	log      logging.Logger
@@ -90,15 +78,11 @@ func (k UpdateSource) FindUpdate(options updater.UpdateOptions) (*updater.Update
 	}
 
 	var reader io.Reader = resp.Body
-	var res updateResponse
-	if err = json.NewDecoder(reader).Decode(&res); err != nil {
+	var update updater.Update
+	if err = json.NewDecoder(reader).Decode(&update); err != nil {
 		return nil, fmt.Errorf("Invalid API response %s", err)
 	}
 
-	if res.Status.Code != 0 {
-		return nil, fmt.Errorf("API returned error response: %#v", res)
-	}
-
-	k.log.Debugf("Received update: %#v", res.Update)
-	return &res.Update, nil
+	k.log.Debugf("Received update: %#v", update)
+	return &update, nil
 }

--- a/keybase/source_test.go
+++ b/keybase/source_test.go
@@ -36,6 +36,12 @@ func newServer(response string) *httptest.Server {
 	}))
 }
 
+func newServerForError(err error) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, err.Error(), 500)
+	}))
+}
+
 func TestUpdateSource(t *testing.T) {
 	server := newServer(updateJSONResponse)
 	defer server.Close()
@@ -54,12 +60,13 @@ func TestUpdateSource(t *testing.T) {
 }
 
 func TestUpdateSourceBadResponse(t *testing.T) {
-	server := newServer("")
+	server := newServerForError(fmt.Errorf("Bad response"))
 	defer server.Close()
 
 	updateSource := newUpdateSource(server.URL, log)
 	options := updater.UpdateOptions{}
 	update, err := updateSource.FindUpdate(options)
+	t.Logf("Error: %s", err)
 	assert.Error(t, err)
 	assert.Nil(t, update, "Shouldn't have update")
 }

--- a/keybase/source_test.go
+++ b/keybase/source_test.go
@@ -14,10 +14,6 @@ import (
 )
 
 const updateJSONResponse = `{
-	"status": {
-		"code": 0
-	},
-	"update": {
 		"version": "1.0.15-20160414190014+fdfce90",
 		"name": "v1.0.15-20160414190014+fdfce90",
 		"installId": "deadbeef",
@@ -31,15 +27,7 @@ const updateJSONResponse = `{
 			"signature": "BEGIN KEYBASE SALTPACK DETACHED SIGNATURE. kXR7VktZdyH7rvq v5wcIkPOwDJ1n11 M8RnkLKQGO2f3Bb fzCeMYz4S6oxLAy Cco4N255JFgnUxK yZ7SITOx8887cOR aeLbQGWBTMZWEQR hL6bhOCR8CqdXaQ 71lCQkT4WsnqAZe 7bbU2Xrsl50sLbJ BN19a9r6bQBYjce gfK0xY0064VY6CW 9. END KEYBASE SALTPACK DETACHED SIGNATURE.\n",
 			"localPath": ""
 		}
-	}
-}
-`
-
-const updateBadResponse = `{
-	"status": {
-		"code": 218
-	}
-}`
+	}`
 
 func newServer(response string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -66,7 +54,7 @@ func TestUpdateSource(t *testing.T) {
 }
 
 func TestUpdateSourceBadResponse(t *testing.T) {
-	server := newServer(updateBadResponse)
+	server := newServer("")
 	defer server.Close()
 
 	updateSource := newUpdateSource(server.URL, log)


### PR DESCRIPTION
@maxtaco 

I'm ok with this.. if the HTTP response is not 200, then it's an error, the status object would be redundant