### PR TITLE
Exit for restart

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ before_install:
   - go get github.com/modocache/gover
   - go get github.com/keybase/go-updater/test
 script:
-  - go test -coverprofile=command.coverprofile ./command
-  - go test -coverprofile=keybase.coverprofile ./keybase
-  - go test -coverprofile=process.coverprofile ./process
-  - go test -coverprofile=service.coverprofile ./service
-  - go test -coverprofile=sources.coverprofile ./sources
-  - go test -coverprofile=util.coverprofile ./util
-  - go test -coverprofile=main.coverprofile
+  - go test -v -coverprofile=command.coverprofile ./command
+  - go test -v -coverprofile=keybase.coverprofile ./keybase
+  - go test -v -coverprofile=process.coverprofile ./process
+  - go test -v -coverprofile=service.coverprofile ./service
+  - go test -v -coverprofile=sources.coverprofile ./sources
+  - go test -v -coverprofile=util.coverprofile ./util
+  - go test -v -coverprofile=main.coverprofile
   - $HOME/gopath/bin/gover
   - $HOME/gopath/bin/goveralls -coverprofile=gover.coverprofile -service=travis-ci

--- a/keybase/source.go
+++ b/keybase/source.go
@@ -63,6 +63,8 @@ func (k UpdateSource) findUpdate(options updater.UpdateOptions, timeout time.Dur
 	urlValues.Add("run_mode", options.Env)
 	urlValues.Add("os_version", options.OSVersion)
 	urlValues.Add("upd_version", options.UpdaterVersion)
+	// Temporarily adding for testing
+	urlValues.Add("channel", "test")
 
 	autoUpdate, _ := k.cfg.GetUpdateAuto()
 	urlValues.Add("auto_update", util.URLValueForBool(autoUpdate))

--- a/process/process_linux_test.go
+++ b/process/process_linux_test.go
@@ -25,7 +25,7 @@ func TestTerminateAll(t *testing.T) {
 	pids := []int{}
 	pids = append(pids, start())
 	pids = append(pids, start())
-	TerminateAll("sleep", time.Millisecond, log)
+	TerminateAll("sleep", time.Millisecond, testLog)
 	assertTerminated(t, pids[0])
 	assertTerminated(t, pids[1])
 }

--- a/service/service.go
+++ b/service/service.go
@@ -32,7 +32,8 @@ func (s *service) Start() {
 		s.updateChecker = &updateChecker
 	}
 	s.updateChecker.Start()
-	s.updateChecker.Check()
+	// If you want to check on service startup
+	//s.updateChecker.Check()
 }
 
 func (s *service) Run() int {

--- a/update_checker.go
+++ b/update_checker.go
@@ -38,9 +38,11 @@ func (u *UpdateChecker) check() error {
 	u.count++
 	update, err := u.updater.Update(u.ctx)
 	if update != nil {
-		// If we received an update let's exit, so the watchdog process can restart
-		// us, no matter what, even if there was an error, and even if the update
-		//  was or wasn't applied.
+		// If we received an update from the check let's exit, so the watchdog
+		// process (e.g. launchd of darwin) can restart us, no matter what, even if
+		// there was an error, and even if the update was or wasn't applied.
+		// There is no difference between doing another update check in a loop after
+		// delay and restarting the service.
 		u.log.Info("Exiting for restart")
 		os.Exit(0)
 	}

--- a/update_checker.go
+++ b/update_checker.go
@@ -4,6 +4,7 @@
 package updater
 
 import (
+	"os"
 	"time"
 
 	"github.com/keybase/go-logging"
@@ -35,7 +36,14 @@ func newUpdateChecker(updater *Updater, ctx Context, log logging.Logger, tickDur
 
 func (u *UpdateChecker) check() error {
 	u.count++
-	_, err := u.updater.Update(u.ctx)
+	update, err := u.updater.Update(u.ctx)
+	if update != nil {
+		// If we received an update let's exit, so the watchdog process can restart
+		// us, no matter what, even if there was an error, and even if the update
+		//  was or wasn't applied.
+		u.log.Info("Exiting for restart")
+		os.Exit(0)
+	}
 	return err
 }
 

--- a/update_checker.go
+++ b/update_checker.go
@@ -22,7 +22,7 @@ type UpdateChecker struct {
 
 // NewUpdateChecker creates an update checker
 func NewUpdateChecker(updater *Updater, ctx Context, log logging.Logger) UpdateChecker {
-	return newUpdateChecker(updater, ctx, log, DefaultTickDuration())
+	return newUpdateChecker(updater, ctx, log, time.Hour)
 }
 
 func newUpdateChecker(updater *Updater, ctx Context, log logging.Logger, tickDuration time.Duration) UpdateChecker {
@@ -81,9 +81,4 @@ func (u *UpdateChecker) Stop() {
 // Count is number of times the check has been called
 func (u UpdateChecker) Count() int {
 	return u.count
-}
-
-// DefaultTickDuration is how often to call check
-func DefaultTickDuration() time.Duration {
-	return time.Hour
 }

--- a/update_checker.go
+++ b/update_checker.go
@@ -39,7 +39,7 @@ func (u *UpdateChecker) check() error {
 	update, err := u.updater.Update(u.ctx)
 	if update != nil {
 		// If we received an update from the check let's exit, so the watchdog
-		// process (e.g. launchd of darwin) can restart us, no matter what, even if
+		// process (e.g. launchd on darwin) can restart us, no matter what, even if
 		// there was an error, and even if the update was or wasn't applied.
 		// There is no difference between doing another update check in a loop after
 		// delay and restarting the service.

--- a/updater.go
+++ b/updater.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the updater version
-const Version = "0.2.1"
+const Version = "0.2.2"
 
 // Updater knows how to find and apply updates
 type Updater struct {
@@ -119,6 +119,7 @@ func (u *Updater) update(ctx Context, options UpdateOptions) (*Update, error) {
 		return update, err
 	}
 
+	u.log.Info("Restarting")
 	if err := ctx.Restart(); err != nil {
 		return update, restartErr(err)
 	}
@@ -127,14 +128,17 @@ func (u *Updater) update(ctx Context, options UpdateOptions) (*Update, error) {
 }
 
 func (u *Updater) apply(ctx Context, update Update, options UpdateOptions) error {
+	u.log.Info("Before apply")
 	if err := ctx.BeforeApply(update); err != nil {
 		return applyErr(err)
 	}
 
+	u.log.Info("Applying update")
 	if err := u.platformApplyUpdate(update, options); err != nil {
 		return applyErr(err)
 	}
 
+	u.log.Info("After apply")
 	if err := ctx.AfterApply(update); err != nil {
 		return applyErr(err)
 	}


### PR DESCRIPTION
Exiting after update check allows the updater to restart.

From the comment above the exit:
```go
// If we received an update from the check let's exit, so the watchdog
// process (e.g. launchd on darwin) can restart us, no matter what, even if
// there was an error, and even if the update was or wasn't applied.
// There is no difference between doing another update check in a loop after
// delay and restarting the service.
```

Also temporarily setting test channel, bumping version and adding some logging.

