### PR TITLE
Command line update check

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -36,10 +36,9 @@ func (s *service) Start() {
 	//s.updateChecker.Check()
 }
 
-func (s *service) Run() int {
+func (s *service) Run() {
 	s.Start()
 	<-s.ch
-	return 0
 }
 
 func (s *service) Quit() {


### PR DESCRIPTION
Add a "check" arg, so you can perform an update check manually from command line.

This has a super minimal impact so I think safe to add in the service exectuable.

@keybase/updater-hackers 