### PR TITLE
Env vars for testing

### DIFF
--- a/keybase/source.go
+++ b/keybase/source.go
@@ -98,5 +98,11 @@ func (k UpdateSource) findUpdate(options updater.UpdateOptions, timeout time.Dur
 	}
 
 	k.log.Debugf("Received update: %#v", update)
+
+	if util.EnvBool("KEYBASE_UPDATER_FORCE", false) {
+		k.log.Info("KEYBASE_UPDATER_FORCE is true, enabling NeedUpdate")
+		update.NeedUpdate = true
+	}
+
 	return &update, nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -4,9 +4,14 @@
 package main
 
 import (
+	"time"
+
 	"github.com/keybase/go-logging"
 	"github.com/keybase/go-updater"
+	"github.com/keybase/go-updater/util"
 )
+
+const defaultTickDuration = time.Hour
 
 type service struct {
 	updater       *updater.Updater
@@ -28,7 +33,8 @@ func newService(upd *updater.Updater, context updater.Context, log logging.Logge
 
 func (s *service) Start() {
 	if s.updateChecker == nil {
-		updateChecker := updater.NewUpdateChecker(s.updater, s.context, s.log)
+		tickDuration := util.EnvDuration("KEYBASE_UPDATER_DELAY", defaultTickDuration)
+		updateChecker := updater.NewUpdateChecker(s.updater, s.context, tickDuration, s.log)
 		s.updateChecker = &updateChecker
 	}
 	s.updateChecker.Start()

--- a/update_checker.go
+++ b/update_checker.go
@@ -21,11 +21,7 @@ type UpdateChecker struct {
 }
 
 // NewUpdateChecker creates an update checker
-func NewUpdateChecker(updater *Updater, ctx Context, log logging.Logger) UpdateChecker {
-	return newUpdateChecker(updater, ctx, log, time.Hour)
-}
-
-func newUpdateChecker(updater *Updater, ctx Context, log logging.Logger, tickDuration time.Duration) UpdateChecker {
+func NewUpdateChecker(updater *Updater, ctx Context, tickDuration time.Duration, log logging.Logger) UpdateChecker {
 	return UpdateChecker{
 		updater:      updater,
 		ctx:          ctx,
@@ -63,7 +59,7 @@ func (u *UpdateChecker) Start() bool {
 	}
 	u.ticker = time.NewTicker(u.tickDuration)
 	go func() {
-		u.log.Debug("Starting (ticker)")
+		u.log.Debugf("Starting (ticker %s)", u.tickDuration)
 		for range u.ticker.C {
 			u.log.Debug("Checking for update (ticker)")
 			u.Check()

--- a/update_checker_test.go
+++ b/update_checker_test.go
@@ -18,7 +18,7 @@ func TestUpdateChecker(t *testing.T) {
 	updater, err := newTestUpdaterWithServer(t, testServer, testUpdate(testServer.URL), &testConfig{})
 	assert.NoError(t, err)
 
-	checker := newUpdateChecker(updater, testUpdateCheckUI{promptDelay: 10 * time.Millisecond}, log, time.Millisecond)
+	checker := NewUpdateChecker(updater, testUpdateCheckUI{promptDelay: 10 * time.Millisecond}, time.Millisecond, log)
 	defer checker.Stop()
 	started := checker.Start()
 	require.True(t, started)
@@ -78,7 +78,7 @@ func TestUpdateCheckerError(t *testing.T) {
 	updater, err := newTestUpdaterWithServer(t, testServer, testUpdate(testServer.URL), &testConfig{})
 	assert.NoError(t, err)
 
-	checker := NewUpdateChecker(updater, testUpdateCheckUI{verifyError: fmt.Errorf("Test verify error")}, log)
+	checker := NewUpdateChecker(updater, testUpdateCheckUI{verifyError: fmt.Errorf("Test verify error")}, time.Minute, log)
 	err = checker.check()
 	require.Error(t, err)
 }

--- a/updater.go
+++ b/updater.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version is the updater version
-const Version = "0.2.2"
+const Version = "0.2.3"
 
 // Updater knows how to find and apply updates
 type Updater struct {

--- a/util/env.go
+++ b/util/env.go
@@ -1,0 +1,48 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package util
+
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+type envFn func(e string) string
+
+// EnvDuration returns a duration from an environment variable or default if
+// invalid or not specified
+func EnvDuration(envVar string, defaultValue time.Duration) time.Duration {
+	return envDuration(os.Getenv, envVar, defaultValue)
+}
+
+func envDuration(fn envFn, envVar string, defaultValue time.Duration) time.Duration {
+	envVal := fn(envVar)
+	if envVal == "" {
+		return defaultValue
+	}
+	duration, err := time.ParseDuration(envVal)
+	if err != nil {
+		return defaultValue
+	}
+	return duration
+}
+
+// EnvBool returns a bool from an environment variable or default if invalid or
+// not specified
+func EnvBool(envVar string, defaultValue bool) bool {
+	return envBool(os.Getenv, envVar, defaultValue)
+}
+
+func envBool(fn envFn, envVar string, defaultValue bool) bool {
+	envVal := fn(envVar)
+	if envVal == "" {
+		return defaultValue
+	}
+	b, err := strconv.ParseBool(envVal)
+	if err != nil {
+		return defaultValue
+	}
+	return b
+}

--- a/util/env_test.go
+++ b/util/env_test.go
@@ -1,0 +1,51 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// testEnvFn returns value
+func testEnvFn(k, v string) func(e string) string {
+	return func(e string) string {
+		if k == e {
+			return v
+		}
+		return ""
+	}
+}
+
+func TestEnvDuration(t *testing.T) {
+	var duration time.Duration
+	duration = envDuration(testEnvFn("TEST", "1s"), "TEST", time.Minute)
+	assert.Equal(t, time.Second, duration)
+	duration = envDuration(testEnvFn("TEST", ""), "TEST", time.Minute)
+	assert.Equal(t, time.Minute, duration)
+	duration = envDuration(testEnvFn("TEST", "invalid"), "TEST", time.Minute)
+	assert.Equal(t, time.Minute, duration)
+	duration = EnvDuration("TEST", time.Hour)
+	assert.Equal(t, time.Hour, duration)
+}
+
+func TestEnvBool(t *testing.T) {
+	var b bool
+	b = envBool(testEnvFn("TEST", "true"), "TEST", false)
+	assert.True(t, b)
+	b = envBool(testEnvFn("TEST", "1"), "TEST", false)
+	assert.True(t, b)
+	b = envBool(testEnvFn("TEST", "false"), "TEST", true)
+	assert.False(t, b)
+	b = envBool(testEnvFn("TEST", "0"), "TEST", false)
+	assert.False(t, b)
+	b = envBool(testEnvFn("TEST", ""), "TEST", false)
+	assert.False(t, b)
+	b = envBool(testEnvFn("TEST", ""), "TEST", true)
+	assert.True(t, b)
+	b = EnvBool("TEST", true)
+	assert.True(t, b)
+}


### PR DESCRIPTION
`KEYBASE_UPDATER_DELAY`: Duration for update delay, e.g. 1m = 1 minute
`KEYBASE_UPDATER_FORCE`: To force latest update to always be applied

To set these you can do:
```
launchctl setenv KEYBASE_UPDATER_DELAY 1m
launchctl setenv KEYBASE_UPDATER_FORCE true
keybase launchd restart keybase.updater
```