### PR TITLE
Update go-ps library

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -26,7 +26,12 @@ func findPIDsWithFn(fn processesFn, prefix string, log logging.Logger) ([]int, e
 	}
 	pids := []int{}
 	for _, p := range processes {
-		if strings.HasPrefix(p.Executable(), prefix) {
+		path, err := p.Path()
+		if err != nil {
+			log.Warningf("Unable to get path for process: %s (%d)", err, p.Pid())
+			continue
+		}
+		if strings.HasPrefix(path, prefix) {
 			pids = append(pids, p.Pid())
 		}
 	}

--- a/process/process.go
+++ b/process/process.go
@@ -28,8 +28,8 @@ func findPIDsWithFn(fn processesFn, prefix string, log logging.Logger) ([]int, e
 	for _, p := range processes {
 		path, err := p.Path()
 		if err != nil {
-			log.Warningf("Unable to get path for process: %s (%d)", err, p.Pid())
-			continue
+			log.Warningf("Unable to get path for process: %s (will use executable name)", err)
+			path = p.Executable()
 		}
 		if strings.HasPrefix(path, prefix) {
 			pids = append(pids, p.Pid())

--- a/vendor/github.com/keybase/go-ps/process.go
+++ b/vendor/github.com/keybase/go-ps/process.go
@@ -19,6 +19,9 @@ type Process interface {
 	// Executable name running this process. This is not a path to the
 	// executable.
 	Executable() string
+
+	// Path is full path to the executable.
+	Path() (string, error)
 }
 
 // Processes returns all processes.

--- a/vendor/github.com/keybase/go-ps/process_freebsd.go
+++ b/vendor/github.com/keybase/go-ps/process_freebsd.go
@@ -5,6 +5,7 @@ package ps
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"syscall"
 	"unsafe"
 )
@@ -123,6 +124,10 @@ func (p *UnixProcess) PPid() int {
 
 func (p *UnixProcess) Executable() string {
 	return p.binary
+}
+
+func (p *UnixProcess) Path() (string, error) {
+	return "", fmt.Errorf("Unsupported")
 }
 
 // Refresh reloads all the data associated with this process.

--- a/vendor/github.com/keybase/go-ps/process_unix.go
+++ b/vendor/github.com/keybase/go-ps/process_unix.go
@@ -35,6 +35,10 @@ func (p *UnixProcess) Executable() string {
 	return p.binary
 }
 
+func (p *UnixProcess) Path() (string, error) {
+	return "", fmt.Errorf("Unsupported")
+}
+
 // Refresh reloads all the data associated with this process.
 func (p *UnixProcess) Refresh() error {
 	statPath := fmt.Sprintf("/proc/%d/stat", p.pid)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -34,8 +34,8 @@
 		},
 		{
 			"path": "github.com/keybase/go-ps",
-			"revision": "a8a6934eedc5edec5b4d43079cb13c1011f01867",
-			"revisionTime": "2016-05-05T10:16:38-07:00"
+			"revision": "439206064b05a100ab19951da2133fc788d13895",
+			"revisionTime": "2016-05-13T17:06:19-07:00"
 		},
 		{
 			"path": "github.com/keybase/saltpack",


### PR DESCRIPTION
This fixes the updater to use this recent fixes in the go-ps library.

The go-ps library had inconsistent values for process Executable() across platforms. The go-ps change vendored here makes the Executable() be the process filename on all platforms, and adds a Path() method for the full path on supported platforms.

