### PR TITLE
Send force param to API (update.json)

### DIFF
--- a/keybase/source.go
+++ b/keybase/source.go
@@ -68,6 +68,7 @@ func (k UpdateSource) findUpdate(options updater.UpdateOptions, timeout time.Dur
 
 	force := util.EnvBool("KEYBASE_UPDATER_FORCE", false)
 	if force {
+		k.log.Info("KEYBASE_UPDATER_FORCE is true, will force update")
 		urlValues.Add("force", util.URLValueForBool(force))
 	}
 

--- a/keybase/source.go
+++ b/keybase/source.go
@@ -66,6 +66,11 @@ func (k UpdateSource) findUpdate(options updater.UpdateOptions, timeout time.Dur
 	// Temporarily adding for testing
 	urlValues.Add("channel", "test")
 
+	force := util.EnvBool("KEYBASE_UPDATER_FORCE", false)
+	if force {
+		urlValues.Add("force", util.URLValueForBool(force))
+	}
+
 	autoUpdate, _ := k.cfg.GetUpdateAuto()
 	urlValues.Add("auto_update", util.URLValueForBool(autoUpdate))
 
@@ -98,11 +103,6 @@ func (k UpdateSource) findUpdate(options updater.UpdateOptions, timeout time.Dur
 	}
 
 	k.log.Debugf("Received update response: %#v", update)
-
-	if util.EnvBool("KEYBASE_UPDATER_FORCE", false) {
-		k.log.Info("KEYBASE_UPDATER_FORCE is true, enabling NeedUpdate")
-		update.NeedUpdate = true
-	}
 
 	return &update, nil
 }


### PR DESCRIPTION
The API should return NeedUpdate to true on response and include a requestId when passing force=1 to update.json endpoint.