### PR TITLE
Use temp dir for asset download

### DIFF
--- a/keybase/platform_darwin_test.go
+++ b/keybase/platform_darwin_test.go
@@ -86,6 +86,7 @@ func TestFindPIDsLaunchd(t *testing.T) {
 func TestApplyNoAsset(t *testing.T) {
 	ctx := newContext(&testConfigPlatform{}, testLog)
 	tmpDir, err := util.WriteTempDir("TestApplyNoAsset.", 0700)
+	defer util.RemoveFileAtPath(tmpDir)
 	require.NoError(t, err)
 	err = ctx.Apply(testUpdate, testOptions, tmpDir)
 	require.EqualError(t, err, "No asset")
@@ -94,6 +95,7 @@ func TestApplyNoAsset(t *testing.T) {
 func TestApplyAsset(t *testing.T) {
 	ctx := newContext(&testConfigPlatform{}, testLog)
 	tmpDir, err := util.WriteTempDir("TestApplyAsset.", 0700)
+	defer util.RemoveFileAtPath(tmpDir)
 	require.NoError(t, err)
 
 	zipPath := filepath.Join(os.Getenv("GOPATH"), "src/github.com/keybase/go-updater/test/test.zip")

--- a/keybase/platform_linux_test.go
+++ b/keybase/platform_linux_test.go
@@ -35,6 +35,7 @@ func TestRestart(t *testing.T) {
 func TestApplyNoAsset(t *testing.T) {
 	ctx := newContext(&testConfigPlatform{}, testLog)
 	tmpDir, err := util.WriteTempDir("TestApplyNoAsset.", 0700)
+	defer util.RemoveFileAtPath(tmpDir)
 	require.NoError(t, err)
 	err = ctx.Apply(testUpdate, testOptions, tmpDir)
 	require.NoError(err)

--- a/keybase/platform_windows_test.go
+++ b/keybase/platform_windows_test.go
@@ -26,6 +26,7 @@ func TestUpdatePrompt(t *testing.T) {
 func TestApplyNoAsset(t *testing.T) {
 	ctx := newContext(&testConfigPlatform{}, testLog)
 	tmpDir, err := util.WriteTempDir("TestApplyNoAsset.", 0700)
+	defer util.RemoveFileAtPath(tmpDir)
 	require.NoError(t, err)
 	err = ctx.Apply(testUpdate, testOptions, tmpDir)
 	require.EqualError(t, err, "No asset")
@@ -34,6 +35,7 @@ func TestApplyNoAsset(t *testing.T) {
 func TestApplyAsset(t *testing.T) {
 	ctx := newContext(&testConfigPlatform{}, testLog)
 	tmpDir, err := util.WriteTempDir("TestApplyAsset.", 0700)
+	defer util.RemoveFileAtPath(tmpDir)
 	require.NoError(t, err)
 
 	exePath := filepath.Join(os.Getenv("GOPATH"), "bin", "test.exe")

--- a/updater_test.go
+++ b/updater_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/keybase/go-logging"
+	"github.com/keybase/go-updater/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -391,7 +392,10 @@ func TestUpdaterAuto(t *testing.T) {
 func TestUpdaterDownloadNil(t *testing.T) {
 	upr, err := newTestUpdater(t)
 	require.NoError(t, err)
-	err = upr.downloadAsset(nil, UpdateOptions{})
+	tmpDir, err := util.WriteTempDir("TestUpdaterDownloadNil", 0700)
+	defer util.RemoveFileAtPath(tmpDir)
+	require.NoError(t, err)
+	err = upr.downloadAsset(nil, tmpDir, UpdateOptions{})
 	assert.EqualError(t, err, "No asset to download")
 }
 

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -174,7 +174,8 @@ func TestMoveFileDirValid(t *testing.T) {
 	assert.True(t, exists)
 
 	// Move again with different source data, and overwrite
-	sourcePath2, err := WriteTempDir("TestMoveDir", 0700)
+	sourcePath2, err := WriteTempDir("TestMoveDir2", 0700)
+	defer RemoveFileAtPath(sourcePath2)
 	err = MoveFile(sourcePath2, destinationPath, "", testLog)
 	assert.NoError(t, err)
 	exists, err = FileExists(destinationPath)


### PR DESCRIPTION
This also keeps the file extension which is important for Windows.
Also cleaning up some tmp dirs that weren't being removed after tests.