### PR TITLE
Display notification in Linux when an update is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The main package is the updater core, there are other support packages:
 
 ### Development
 
-This libray should pass the [gometalinter](https://github.com/alecthomas/gometalinter).
+This library should pass the [gometalinter](https://github.com/alecthomas/gometalinter).
 
 There is a pre-commit hook available:
 

--- a/error.go
+++ b/error.go
@@ -66,7 +66,8 @@ func (e Error) Error() string {
 	return fmt.Sprintf("Update Error (%s): %s", e.TypeString(), e.source.Error())
 }
 
-func cancelErr(err error) Error {
+// CancelError can be returned by lifecycle methods to abort an update
+func CancelErr(err error) Error {
 	return NewError(CancelError, err)
 }
 

--- a/keybase/config.go
+++ b/keybase/config.go
@@ -126,7 +126,7 @@ func (c config) saveToPath(path string) error {
 }
 
 // GetUpdateAuto is the whether to update automatically and whether the user has
-// set this value. Both shouble be true for an update to be automatically
+// set this value. Both should be true for an update to be automatically
 // applied.
 func (c config) GetUpdateAuto() (bool, bool) {
 	return c.store.Auto, c.store.AutoSet

--- a/keybase/config.go
+++ b/keybase/config.go
@@ -22,6 +22,7 @@ type Config interface {
 	updater.Config
 	keybasePath() string
 	promptProgram() (command.Program, error)
+	notifyProgram() string
 	destinationPath() string
 	updaterOptions() updater.UpdateOptions
 }

--- a/keybase/platform_darwin.go
+++ b/keybase/platform_darwin.go
@@ -92,6 +92,15 @@ func (c config) promptProgram() (command.Program, error) {
 	}, nil
 }
 
+func (c config) notifyProgram() string {
+	// No notify program for Darwin
+	return ""
+}
+
+func (c context) BeforeUpdatePrompt(update updater.Update, options updater.UpdateOptions) error {
+	return nil
+}
+
 // UpdatePrompt is called when the user needs to accept an update
 func (c context) UpdatePrompt(update updater.Update, options updater.UpdateOptions, promptOptions updater.UpdatePromptOptions) (*updater.UpdatePromptResponse, error) {
 	promptProgram, err := c.config.promptProgram()

--- a/keybase/platform_linux.go
+++ b/keybase/platform_linux.go
@@ -65,6 +65,24 @@ func (c config) promptProgram() (command.Program, error) {
 	return command.Program{}, fmt.Errorf("Unsupported")
 }
 
+func (c config) notifyProgram() string {
+	return "notify-send"
+}
+
+func (c context) BeforeUpdatePrompt(update updater.Update, options updater.UpdateOptions) error {
+	notifyArgs := []string{
+		"-i", "/usr/share/icons/hicolor/128x128/apps/keybase.png",
+		fmt.Sprintf("New Keybase version: %s", update.Version),
+		fmt.Sprintf("Please update Keybase using your system package manager."),
+	}
+	result, err := command.Exec("notify-send", notifyArgs, 5*time.Second, c.log)
+	if err != nil {
+		c.log.Warningf("Error running notify-send: %s (%s)", err, result.CombinedOutput())
+	}
+	c.ReportAction(updater.UpdateActionSnooze, &update, options)
+	return updater.CancelErr(fmt.Errorf("Linux uses system package manager"))
+}
+
 func (c context) UpdatePrompt(update updater.Update, options updater.UpdateOptions, promptOptions updater.UpdatePromptOptions) (*updater.UpdatePromptResponse, error) {
 	// No update prompt for Linux
 	return &updater.UpdatePromptResponse{Action: updater.UpdateActionContinue}, nil

--- a/keybase/platform_linux_test.go
+++ b/keybase/platform_linux_test.go
@@ -14,6 +14,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBeforeUpdatePrompt(t *testing.T) {
+	ctx := newContext(&testConfigPlatform{}, testLog)
+	err := ctx.BeforeUpdatePrompt(testUpdate, testOptions)
+	assert.EqualError(t, err, "Update Error (cancel): Linux uses system package manager")
+}
+
 func TestUpdatePrompt(t *testing.T) {
 	ctx := newContext(&testConfigPlatform{}, testLog)
 	resp, err := ctx.UpdatePrompt(testUpdate, testOptions, updater.UpdatePromptOptions{})

--- a/keybase/platform_linux_test.go
+++ b/keybase/platform_linux_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
-// +build darwin
+// +build linux
 
 package keybase
 
@@ -16,8 +16,9 @@ import (
 
 func TestUpdatePrompt(t *testing.T) {
 	ctx := newContext(&testConfigPlatform{}, testLog)
-	_, err := ctx.UpdatePrompt(testUpdate, testOptions, updater.UpdatePromptOptions{})
-	assert.Error(t, err, "Unsupported")
+	resp, err := ctx.UpdatePrompt(testUpdate, testOptions, updater.UpdatePromptOptions{})
+	assert.Equal(t, &updater.UpdatePromptResponse{Action: updater.UpdateActionContinue}, resp)
+	require.NoError(t, err)
 }
 
 func TestPausedPrompt(t *testing.T) {
@@ -38,5 +39,5 @@ func TestApplyNoAsset(t *testing.T) {
 	defer util.RemoveFileAtPath(tmpDir)
 	require.NoError(t, err)
 	err = ctx.Apply(testUpdate, testOptions, tmpDir)
-	require.NoError(err)
+	require.NoError(t, err)
 }

--- a/keybase/platform_test.go
+++ b/keybase/platform_test.go
@@ -23,3 +23,7 @@ func (c testConfigPlatform) promptProgram() (command.Program, error) {
 			}`},
 	}, nil
 }
+
+func (c testConfigPlatform) notifyProgram() string {
+	return "echo"
+}

--- a/keybase/platform_windows.go
+++ b/keybase/platform_windows.go
@@ -49,6 +49,15 @@ func (c config) promptProgram() (command.Program, error) {
 	return command.Program{}, fmt.Errorf("Unsupported")
 }
 
+func (c config) notifyProgram() string {
+	// No notify program for Windows
+	return ""
+}
+
+func (c context) BeforeUpdatePrompt(update updater.Update, options updater.UpdateOptions) error {
+	return nil
+}
+
 func (c context) UpdatePrompt(update updater.Update, options updater.UpdateOptions, promptOptions updater.UpdatePromptOptions) (*updater.UpdatePromptResponse, error) {
 	// No update prompt for Windows, since the installer may handle it
 	return &updater.UpdatePromptResponse{Action: updater.UpdateActionContinue}, nil

--- a/update_checker_test.go
+++ b/update_checker_test.go
@@ -41,6 +41,10 @@ type testUpdateCheckUI struct {
 	verifyError error
 }
 
+func (u testUpdateCheckUI) BeforeUpdatePrompt(_ Update, _ UpdateOptions) error {
+	return nil
+}
+
 func (u testUpdateCheckUI) UpdatePrompt(_ Update, _ UpdateOptions, _ UpdatePromptOptions) (*UpdatePromptResponse, error) {
 	return &UpdatePromptResponse{Action: UpdateActionApply}, nil
 }

--- a/updater_test.go
+++ b/updater_test.go
@@ -53,6 +53,10 @@ type testUpdateUI struct {
 	successReported    bool
 }
 
+func (u testUpdateUI) BeforeUpdatePrompt(_ Update, _ UpdateOptions) error {
+	return nil
+}
+
 func (u testUpdateUI) UpdatePrompt(_ Update, _ UpdateOptions, _ UpdatePromptOptions) (*UpdatePromptResponse, error) {
 	if u.promptErr != nil {
 		return nil, u.promptErr


### PR DESCRIPTION
@gabriel Here's a stab at displaying notifications in place of prompting/installing updates on Linux.

Demo output:

```
ubuntu@keybase-ui:~/go/src/github.com/keybase/go-updater$ DISPLAY=:0 ~/updater check
2016/06/03 23:51:48 Execute:  [version -S]
2016/06/03 23:51:48 Couldn't get keybase version: No command ([Stdout] 
[Stdrr] )
2016/06/03 23:51:48 Execute: uname [-mrs]
2016/06/03 23:51:48 Checking for update, current version is 
2016/06/03 23:51:48 Using updater source: Keybase.io
2016/06/03 23:51:48 Using options: updater.UpdateOptions{Version:"", Platform:"linux", DestinationPath:"", URL:"", Channel:"test", Env:"prod", Arch:"amd64", Force:false, OSVersion:"Linux 4.4.0-21-generic x86_64", UpdaterVersion:"0.2.4"}
2016/06/03 23:51:48 Request "https://api.keybase.io/_/api/1.0/pkg/update.json?auto_update=0&channel=test&install_id=1d2a39315277d08e8444549a88db6c991330eed1d8da0e1d&os_version=Linux+4.4.0-21-generic+x86_64&platform=linux&run_mode=prod&upd_version=0.2.4&version="
2016/06/03 23:51:49 Received update response: updater.Update{Version:"1.0.16-20160602173256+05ffb21", Name:"v1.0.16-20160602173256+05ffb21", Description:"Latest Linux release", InstallID:"1d2a39315277d08e8444549a88db6c991330eed1d8da0e1d", RequestID:"0a745ac51587968b6cae711f", Type:0, PublishedAt:1464888776000, Asset:(*updater.Asset)(nil), NeedUpdate:true}
2016/06/03 23:51:49 Got update with version: 1.0.16-20160602173256+05ffb21
2016/06/03 23:51:49 Execute: notify-send [-i /usr/share/icons/hicolor/128x128/apps/keybase.png New Keybase version: 1.0.16-20160602173256+05ffb21 Please update Keybase using your system package manager.]
2016/06/03 23:51:49 Update Error (cancel): Linux uses system package manager
```

* [x] Test `BeforeUpdatePrompt`
* [x] ~~Test install id~~
* [x] Snooze

![image](https://cloud.githubusercontent.com/assets/16893/15795937/03280c20-29ab-11e6-8135-92fc890c1982.png)
