### PR TITLE
Fixes keybase update source using stale value of Install ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+
+## ChangeLog
+
+### 0.2.5
+- Fixes bug where keybase update source was using stale value of Install ID
+- Remove hardcoded test channel option (was unused)

--- a/keybase/config.go
+++ b/keybase/config.go
@@ -51,10 +51,10 @@ type store struct {
 }
 
 // newConfig loads a config, which is valid even if it has an error
-func newConfig(appName string, pathToKeybase string, log Log) (config, error) {
+func newConfig(appName string, pathToKeybase string, log Log) (*config, error) {
 	cfg := newDefaultConfig(appName, pathToKeybase, log)
 	err := cfg.load()
-	return cfg, err
+	return &cfg, err
 }
 
 func newDefaultConfig(appName string, pathToKeybase string, log Log) config {
@@ -158,7 +158,6 @@ func (c config) updaterOptions() updater.UpdateOptions {
 		Version:         version,
 		Platform:        runtime.GOOS,
 		Arch:            runtime.GOARCH,
-		Channel:         "test",
 		DestinationPath: c.destinationPath(),
 		Env:             "prod",
 		OSVersion:       osVersion,

--- a/keybase/config_test.go
+++ b/keybase/config_test.go
@@ -13,11 +13,14 @@ import (
 	"github.com/keybase/go-updater"
 	"github.com/keybase/go-updater/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func testConfig(t *testing.T) (config, error) {
+func testConfig(t *testing.T) (*config, error) {
 	testPathToKeybase := filepath.Join(os.Getenv("GOPATH"), "bin", "test")
-	return newConfig("KeybaseTest", testPathToKeybase, testLog)
+	appName, err := util.RandomID("KeybaseTest.")
+	require.NoError(t, err)
+	return newConfig(appName, testPathToKeybase, testLog)
 }
 
 func TestConfig(t *testing.T) {

--- a/keybase/config_test.go
+++ b/keybase/config_test.go
@@ -60,7 +60,7 @@ func TestConfig(t *testing.T) {
 		Version:         "1.2.3-400+cafebeef",
 		Platform:        runtime.GOOS,
 		DestinationPath: options.DestinationPath,
-		Channel:         "test",
+		Channel:         "",
 		Env:             "prod",
 		Arch:            runtime.GOARCH,
 		Force:           false,

--- a/keybase/context.go
+++ b/keybase/context.go
@@ -75,8 +75,8 @@ func NewUpdaterContext(appName string, pathToKeybase string, log Log) (updater.C
 	// For testing
 	// (cd /Applications; ditto -c -k --sequesterRsrc --keepParent Keybase.app /tmp/Keybase.zip)
 	//src := updater.NewLocalUpdateSource("/tmp/Keybase.zip", log)
-	upd := updater.NewUpdater(src, &cfg, log)
-	return newContext(&cfg, log), upd
+	upd := updater.NewUpdater(src, cfg, log)
+	return newContext(cfg, log), upd
 }
 
 // UpdateOptions returns update options

--- a/keybase/context_test.go
+++ b/keybase/context_test.go
@@ -35,7 +35,7 @@ const testSignatureInvalidSigner = `BEGIN KEYBASE SALTPACK DETACHED SIGNATURE.
 
 func testContext(t *testing.T) *context {
 	cfg, _ := testConfig(t)
-	ctx := newContext(&cfg, testLog)
+	ctx := newContext(cfg, testLog)
 	require.NotNil(t, ctx)
 	return ctx
 }

--- a/keybase/prompt_test.go
+++ b/keybase/prompt_test.go
@@ -16,7 +16,7 @@ import (
 
 func testPromptWithProgram(t *testing.T, promptProgram command.Program, timeout time.Duration) (*updater.UpdatePromptResponse, error) {
 	cfg, _ := testConfig(t)
-	ctx := newContext(&cfg, testLog)
+	ctx := newContext(cfg, testLog)
 	assert.NotNil(t, ctx)
 
 	update := updater.Update{
@@ -124,7 +124,7 @@ func TestPromptError(t *testing.T) {
 
 func testPausedPromptWithProgram(t *testing.T, promptProgram command.Program, timeout time.Duration) (bool, error) {
 	cfg, _ := testConfig(t)
-	ctx := newContext(&cfg, testLog)
+	ctx := newContext(cfg, testLog)
 	assert.NotNil(t, ctx)
 	return ctx.pausedPrompt(promptProgram, timeout)
 }

--- a/keybase/source.go
+++ b/keybase/source.go
@@ -17,17 +17,17 @@ import (
 
 // UpdateSource finds releases/updates on keybase.io
 type UpdateSource struct {
-	cfg      config
+	cfg      *config
 	log      Log
 	endpoint string
 }
 
 // NewUpdateSource contructs an update source for keybase.io
-func NewUpdateSource(cfg config, log Log) UpdateSource {
+func NewUpdateSource(cfg *config, log Log) UpdateSource {
 	return newUpdateSource(cfg, defaultEndpoints.update, log)
 }
 
-func newUpdateSource(cfg config, endpoint string, log Log) UpdateSource {
+func newUpdateSource(cfg *config, endpoint string, log Log) UpdateSource {
 	return UpdateSource{
 		cfg:      cfg,
 		endpoint: endpoint,

--- a/updater.go
+++ b/updater.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Version is the updater version
-const Version = "0.2.4"
+const Version = "0.2.5"
 
 // Updater knows how to find and apply updates
 type Updater struct {
@@ -212,6 +212,7 @@ func (u *Updater) checkForUpdate(ctx Context, options UpdateOptions) (*Update, e
 
 	// Save InstallID if we received one
 	if update.InstallID != "" && u.config.GetInstallID() != update.InstallID {
+		u.log.Debugf("Saving install ID: %s", update.InstallID)
 		if err := u.config.SetInstallID(update.InstallID); err != nil {
 			u.log.Warningf("Error saving install ID: %s", err)
 			ctx.ReportError(configErr(fmt.Errorf("Error saving install ID: %s", err)), update, options)

--- a/updater_test.go
+++ b/updater_test.go
@@ -30,7 +30,7 @@ func newTestUpdater(t *testing.T) (*Updater, error) {
 }
 
 func newTestUpdaterWithServer(t *testing.T, testServer *httptest.Server, update *Update, config Config) (*Updater, error) {
-	return NewUpdater(testUpdateSource{testServer: testServer, update: update}, config, testLog), nil
+	return NewUpdater(testUpdateSource{testServer: testServer, config: config, update: update}, config, testLog), nil
 }
 
 func newTestContext(options UpdateOptions, cfg Config, response *UpdatePromptResponse) *testUpdateUI {
@@ -118,6 +118,7 @@ func (u testUpdateUI) UpdateOptions() UpdateOptions {
 
 type testUpdateSource struct {
 	testServer *httptest.Server
+	config     Config
 	update     *Update
 	findErr    error
 }
@@ -434,4 +435,5 @@ func TestUpdaterNotNeeded(t *testing.T) {
 	assert.Nil(t, update)
 
 	assert.False(t, ctx.successReported)
+	assert.Equal(t, "deadbeef", upr.config.GetInstallID())
 }


### PR DESCRIPTION
The `keybase.UpdateSource` (which requests from the keybase.io API endpoint) was getting a copy of config (instead of a config pointer). So any subsequent changes to config (e.g. setting of Install ID) wouldn't be included in requests, and the install_id in the API request was stale. On first installs this means that it would be empty.

However, the install ID does get read correctly after the first update (it sort of fixes itself). This is because when an update occurs, the install ID is saved correctly to config, and at the end of an update, the updater will restart. When the updater starts back up, the `keybase.UpdateSource` reads the new config value and thus can send the correct install ID.

The fix is to have `keybase.UpdateSource` keep a `*config` instead of `config`.

While we did have test coverage to make sure install ID was being saved in the updater tests and in config tests, we didn't have a test to make sure the keybase update source was sending the correct URL params after config changed. This highlights some risks in that we may be lacking "bigger" integration tests that test the whole shebang, in multiple iterations with changing state (e.g. integration tests without anything mocked).

This bug might cause the server to store a lot of install ids that will be unused, that we may need to cleanup. It shouldn't have any other impacts.

This PR also removes a hardcoded "test" channel param which is unused. It bumps the version and includes a ChangeLog.

@keybase/updater-hackers 