### PR TITLE
Request app exit instead of SIGTERM (darwin)

### DIFF
--- a/keybase/context.go
+++ b/keybase/context.go
@@ -72,9 +72,13 @@ func NewUpdaterContext(appName string, pathToKeybase string, log Log) (updater.C
 	}
 
 	src := NewUpdateSource(cfg, log)
-	// For testing
+
+	// For testing, use a local updater source
 	// (cd /Applications; ditto -c -k --sequesterRsrc --keepParent Keybase.app /tmp/Keybase.zip)
-	//src := updater.NewLocalUpdateSource("/tmp/Keybase.zip", log)
+	// keybase sign -d -i "/tmp/Keybase.zip" -o "/tmp/update.sig"
+	// release update-json --version=`keybase version -S` --src=/tmp/Keybase.zip --uri=/tmp --signature=/tmp/update.sig > /tmp/update.json
+	// src := sources.NewLocalUpdateSource("/tmp/Keybase.zip", "/tmp/update.json", log)
+
 	upd := updater.NewUpdater(src, cfg, log)
 	return newContext(cfg, log), upd
 }

--- a/sources/local.go
+++ b/sources/local.go
@@ -47,5 +47,8 @@ func (k LocalUpdateSource) FindUpdate(options updater.UpdateOptions) (*updater.U
 	}
 
 	update.Asset.URL = fmt.Sprintf("file://%s", k.path)
+	// TODO: Only do if version is newer or forced (this source is used for testing, so ok to hardcode NeedUpdate)
+	update.NeedUpdate = true
+	k.log.Debugf("Returning update: %#v", update)
 	return &update, nil
 }


### PR DESCRIPTION
Requests app exit before doing a SIGKILL. I tested both scenarios locally but needs a few days of real testing.