### PR TITLE
Prompt user before overriding auto install

### DIFF
--- a/keybase/config.go
+++ b/keybase/config.go
@@ -36,6 +36,8 @@ type config struct {
 	log Log
 	// store is the config values
 	store store
+	// AutoOverride is whether the current auto setting should be temporarily overridden
+	AutoOverride bool
 }
 
 // store is the config values
@@ -137,6 +139,16 @@ func (c *config) SetUpdateAuto(auto bool) error {
 	c.store.Auto = auto
 	c.store.AutoSet = true
 	return c.save()
+}
+
+// For overriding the current Auto setting
+func (c config) GetUpdateAutoOverride() bool {
+	return c.AutoOverride
+}
+
+func (c *config) SetUpdateAutoOverride(auto bool) error {
+	c.AutoOverride = auto
+	return nil
 }
 
 // GetInstallID is an identifier returned by the API on first update that is a

--- a/keybase/config.go
+++ b/keybase/config.go
@@ -36,8 +36,8 @@ type config struct {
 	log Log
 	// store is the config values
 	store store
-	// AutoOverride is whether the current auto setting should be temporarily overridden
-	AutoOverride bool
+	// autoOverride is whether the current auto setting should be temporarily overridden
+	autoOverride bool
 }
 
 // store is the config values
@@ -143,11 +143,11 @@ func (c *config) SetUpdateAuto(auto bool) error {
 
 // For overriding the current Auto setting
 func (c config) GetUpdateAutoOverride() bool {
-	return c.AutoOverride
+	return c.autoOverride
 }
 
 func (c *config) SetUpdateAutoOverride(auto bool) error {
-	c.AutoOverride = auto
+	c.autoOverride = auto
 	return nil
 }
 

--- a/keybase/config_test.go
+++ b/keybase/config_test.go
@@ -51,6 +51,13 @@ func TestConfig(t *testing.T) {
 	assert.Equal(t, cfg.GetInstallID(), "deadbeef")
 
 	err = cfg.save()
+
+	override := cfg.GetUpdateAutoOverride()
+	assert.False(t, override, "AutoOverride should be false")
+	cfg.SetUpdateAutoOverride(true)
+	override = cfg.GetUpdateAutoOverride()
+	assert.True(t, override, "AutoOverride should be set")
+
 	assert.NoError(t, err)
 
 	options := cfg.updaterOptions()

--- a/keybase/platform_windows.go
+++ b/keybase/platform_windows.go
@@ -80,7 +80,6 @@ type regUninstallGetter func(string, Log) bool
 // among other things generates a log of what it would do. We can parse this
 // for Dokan product code variables, which will be in the registry if the same
 // version is already present.
-//
 func CheckCanBeSilent(path string, log Log, regFunc regUninstallGetter) (bool, error) {
 	tempName := util.TempPath("", "keybaseInstallLayout-")
 
@@ -96,7 +95,7 @@ func CheckCanBeSilent(path string, log Log, regFunc regUninstallGetter) (bool, e
 
 	_, err := command.Exec(path, []string{"/layout", "/quiet", "/log", tempName}, 2*time.Minute, log)
 	if err != nil {
-		log.Errorf("CheckCanBeSilent: Unable to execute %s", path)
+		log.Errorf("CheckCanBeSilent: Unable to execute %s: %s", path, err)
 		return false, err
 	}
 	defer util.RemoveFileAtPath(tempName)
@@ -153,7 +152,7 @@ func checkRebootPending(wow64 bool, log Log) (bool, error) {
 
 	k, err := registry.OpenKey(registry.CURRENT_USER, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\RunOnce", access)
 	if err != nil {
-		log.Errorf("Error %s opening RunOnce subkeys", err.Error())
+		log.Errorf("Error opening RunOnce subkeys: %s", err)
 		return false, err
 	}
 	defer util.Close(k)

--- a/keybase/platform_windows.go
+++ b/keybase/platform_windows.go
@@ -61,7 +61,15 @@ func (c config) notifyProgram() string {
 	return ""
 }
 
-func (c context) BeforeUpdatePrompt(update updater.Update, options updater.UpdateOptions) error {
+func (c *context) BeforeUpdatePrompt(update updater.Update, options updater.UpdateOptions) error {
+	// This is the check whether to override an auto update. Unnecessary if
+	// auto update is not on in the first place.
+	_, auto := c.config.GetUpdateAuto()
+	if auto && !c.config.GetUpdateAutoOverride() {
+		if canBeSilent, _ := CheckCanBeSilent(update.Asset.LocalPath, c.log, CheckRegistryUninstallCode); !canBeSilent {
+			c.config.SetUpdateAutoOverride(true)
+		}
+	}
 	return nil
 }
 
@@ -72,8 +80,19 @@ type regUninstallGetter func(string, Log) bool
 // among other things generates a log of what it would do. We can parse this
 // for Dokan product code variables, which will be in the registry if the same
 // version is already present.
+//
 func CheckCanBeSilent(path string, log Log, regFunc regUninstallGetter) (bool, error) {
 	tempName := util.TempPath("", "keybaseInstallLayout-")
+
+	// Also look in the registry whether a reboot is pending from a previous installer.
+	// Not finding the key is not an error.
+	if rebootPending, err := checkRebootPending(false, log); rebootPending && err == nil {
+		return false, nil
+	}
+
+	if rebootPending, err := checkRebootPending(true, log); rebootPending && err == nil {
+		return false, nil
+	}
 
 	_, err := command.Exec(path, []string{"/layout", "/quiet", "/log", tempName}, 2*time.Minute, log)
 	if err != nil {
@@ -123,6 +142,41 @@ func CheckRegistryUninstallCode(productID string, log Log) bool {
 		return true
 	}
 	return false
+}
+
+// Read all the runonce subkeys and find the one with "Keybase" in the name.
+func checkRebootPending(wow64 bool, log Log) (bool, error) {
+	var access uint32 = registry.ENUMERATE_SUB_KEYS | registry.QUERY_VALUE
+	if wow64 {
+		access = access | registry.WOW64_32KEY
+	}
+
+	k, err := registry.OpenKey(registry.CURRENT_USER, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\RunOnce", access)
+	if err != nil {
+		log.Errorf("Error %s opening RunOnce subkeys", err.Error())
+		return false, err
+	}
+	defer util.Close(k)
+
+	params, err := k.ReadValueNames(0)
+	if err != nil {
+		log.Errorf("Can't ReadSubKeyNames %#v", err)
+		return false, err
+	}
+
+	for _, param := range params {
+		val, _, err := k.GetStringValue(param)
+
+		if err != nil {
+			log.Warningf("Error getting string value for %s: %s", param, err)
+			continue
+		}
+		if strings.Contains(val, "Keybase") {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func (c config) promptProgram() (command.Program, error) {
@@ -192,8 +246,7 @@ func (c context) Apply(update updater.Update, options updater.UpdateOptions, tmp
 	}
 	var args []string
 	auto, _ := c.config.GetUpdateAuto()
-	canBeSilent, _ := CheckCanBeSilent(update.Asset.LocalPath, c.log, CheckRegistryUninstallCode)
-	if auto && canBeSilent {
+	if auto && !c.config.GetUpdateAutoOverride() {
 		args = append(args, "/quiet")
 	}
 	_, err := command.Exec(update.Asset.LocalPath, args, time.Hour, c.log)

--- a/updater.go
+++ b/updater.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Version is the updater version
-const Version = "0.2.5"
+const Version = "0.2.6"
 
 // Updater knows how to find and apply updates
 type Updater struct {

--- a/updater.go
+++ b/updater.go
@@ -51,6 +51,8 @@ type Context interface {
 type Config interface {
 	GetUpdateAuto() (bool, bool)
 	SetUpdateAuto(b bool) error
+	GetUpdateAutoOverride() bool
+	SetUpdateAutoOverride(bool) error
 	GetInstallID() string
 	SetInstallID(installID string) error
 }

--- a/updater_test.go
+++ b/updater_test.go
@@ -156,10 +156,11 @@ func (u testUpdateSource) FindUpdate(options UpdateOptions) (*Update, error) {
 }
 
 type testConfig struct {
-	auto      bool
-	autoSet   bool
-	installID string
-	err       error
+	auto         bool
+	autoSet      bool
+	autoOverride bool
+	installID    string
+	err          error
 }
 
 func (c testConfig) GetUpdateAuto() (bool, bool) {
@@ -170,6 +171,16 @@ func (c *testConfig) SetUpdateAuto(b bool) error {
 	c.auto = b
 	c.autoSet = true
 	return c.err
+}
+
+// For overriding the current Auto setting
+func (c testConfig) GetUpdateAutoOverride() bool {
+	return c.autoOverride
+}
+
+func (c *testConfig) SetUpdateAutoOverride(auto bool) error {
+	c.autoOverride = auto
+	return nil
 }
 
 func (c testConfig) GetInstallID() string {


### PR DESCRIPTION
The current updater will check whether drivers are being updated and launch the installer non-silently in that case. But if "auto" is on, it skips the dialog and just launches this installer, then kills it after an hour. We need to launch the prompter dialog and kill that instead; killing an installer is particularly bad.
@gabriel @maxtaco 