### PR TITLE
util: return error upon failure

### DIFF
--- a/util/unzip.go
+++ b/util/unzip.go
@@ -51,7 +51,7 @@ func unzipOver(sourcePath string, destinationPath string, log Log) error {
 		log.Infof("Removing existing unzip destination path: %s", destinationPath)
 		err := os.RemoveAll(destinationPath)
 		if err != nil {
-			return nil
+			return err
 		}
 	}
 


### PR DESCRIPTION
Return error when `os.RemoveAll` fails.