### PR TITLE
Don't steal focus on update prompt (macOS)

### DIFF
--- a/osx/Updater.xcodeproj/project.pbxproj
+++ b/osx/Updater.xcodeproj/project.pbxproj
@@ -168,12 +168,13 @@
 		00C19B691CB6CE0500BDFDAD /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = Keybase;
 				TargetAttributes = {
 					00C19B701CB6CE0500BDFDAD = {
 						CreatedOnToolsVersion = 7.3;
 						DevelopmentTeam = 99229SGT5K;
+						ProvisioningStyle = Manual;
 					};
 					00E8F4221CBF184900532C84 = {
 						CreatedOnToolsVersion = 7.3;
@@ -276,8 +277,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -320,8 +323,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -347,8 +352,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "Developer ID Application: Keybase, Inc. (99229SGT5K)";
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 99229SGT5K;
 				INFOPLIST_FILE = Updater/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
@@ -361,8 +367,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "Developer ID Application: Keybase, Inc. (99229SGT5K)";
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 99229SGT5K;
 				INFOPLIST_FILE = Updater/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;

--- a/osx/Updater/AppDelegate.m
+++ b/osx/Updater/AppDelegate.m
@@ -17,7 +17,7 @@
   // Check if test environment
   if ([self isRunningTests]) return;
 
-  // Run app as accessory (no dock or menu).
+  // Run as accessory (no dock or menu).
   // The update prompt window will still be modal but won't take focus away from
   // other apps when it pops up.
   [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];

--- a/osx/Updater/AppDelegate.m
+++ b/osx/Updater/AppDelegate.m
@@ -17,7 +17,11 @@
   // Check if test environment
   if ([self isRunningTests]) return;
 
-  [NSApp activateIgnoringOtherApps:YES];
+  // Run app as accessory (no dock or menu).
+  // The update prompt window will still be modal but won't take focus away from
+  // other apps when it pops up.
+  [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+
   dispatch_async(dispatch_get_main_queue(), ^{
     [self run];
   });

--- a/osx/Updater/Info.plist
+++ b/osx/Updater/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.3</string>
+	<string>1.0.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.3</string>
+	<string>1.0.4</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
This changes the app activation policy to be an NSApplicationActivationPolicyAccessory.
This means the app won't take focus away from other apps when the prompt pops up (and won't have a dock or menu).

It will still be modal, so it will live above other windows.

Also updates project for Xcode 8.