### PR TITLE
Change to LSUIElement so we don't change focus initially on start

### DIFF
--- a/osx/Updater/Info.plist
+++ b/osx/Updater/Info.plist
@@ -17,13 +17,15 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.4</string>
+	<string>1.0.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.4</string>
+	<string>1.0.5</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>LSUIElement</key>
+	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2016 Keybase. All rights reserved.</string>
 	<key>NSMainNibFile</key>


### PR DESCRIPTION
There was a chance the update prompt could take focus before it was programmatically set not to. Setting to LSUIElement fixes.
