### PR TITLE
Try privileged keybase uninstall on rename error

### DIFF
--- a/keybase/platform_darwin.go
+++ b/keybase/platform_darwin.go
@@ -263,6 +263,8 @@ func (c context) Apply(update updater.Update, options updater.UpdateOptions, tmp
 		} else {
 			return err
 		}
+	default:
+		return err
 	}
 
 	// Update spotlight

--- a/service/main.go
+++ b/service/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -51,12 +52,11 @@ func defaultAppName() string {
 }
 
 func run(f flags) {
-	ulog := logger{}
-
 	if f.version {
-		ulog.Infof("%s\n", updater.Version)
+		fmt.Printf("%s\n", updater.Version)
 		return
 	}
+	ulog := logger{}
 
 	if f.logToFile {
 		logFile, _, err := ulog.setLogToFile(f.appName, "keybase.updater.log")

--- a/updater.go
+++ b/updater.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Version is the updater version
-const Version = "0.2.6"
+const Version = "0.2.7"
 
 // Updater knows how to find and apply updates
 type Updater struct {


### PR DESCRIPTION
This allows the updater to replace the Keybase.app, even if the Keybase.app is installed by another user.

If we get an `os.LinkError, Op:"rename"` for the Keybase.app when trying to apply, we'll try to do a `keybase uninstall --components=app` which can remove `/Applications/Keybase.app` via the privileged helper.

