### PR TITLE
Increase timeout when getting Keybase version

### DIFF
--- a/keybase/config.go
+++ b/keybase/config.go
@@ -182,7 +182,7 @@ func (c config) keybasePath() string {
 }
 
 func (c config) keybaseVersion() string {
-	result, err := command.Exec(c.keybasePath(), []string{"version", "-S"}, 5*time.Second, c.log)
+	result, err := command.Exec(c.keybasePath(), []string{"version", "-S"}, 20*time.Second, c.log)
 	if err != nil {
 		c.log.Warningf("Couldn't get keybase version: %s (%s)", err, result.CombinedOutput())
 		return ""

--- a/updater.go
+++ b/updater.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Version is the updater version
-const Version = "0.2.7"
+const Version = "0.2.8"
 
 // Updater knows how to find and apply updates
 type Updater struct {


### PR DESCRIPTION
and use 10 second timeout instead of 5 - getting the version has failed on Windows before.
@maxtaco @gabriel 