### PR TITLE
Apply, stop then start

### DIFF
--- a/keybase/context.go
+++ b/keybase/context.go
@@ -126,7 +126,7 @@ func (c context) BeforeApply(update updater.Update) error {
 			return fmt.Errorf("Canceled by user from paused prompt")
 		}
 	}
-	return c.beforeApply(update)
+	return nil
 }
 
 func (c context) AfterUpdateCheck(update *updater.Update) {

--- a/keybase/platform_darwin.go
+++ b/keybase/platform_darwin.go
@@ -152,13 +152,6 @@ func (c context) lookupProcessPaths() (p processPaths, _ error) {
 	return p, nil
 }
 
-func (c context) beforeApply(update updater.Update) error {
-	if err := c.stop(); err != nil {
-		c.log.Warningf("Error trying to stop: %s", err)
-	}
-	return nil
-}
-
 // stop will quit the app and any services
 func (c context) stop() error {
 	// Stop app
@@ -189,6 +182,10 @@ func (c context) stop() error {
 
 // AfterApply is called after an update is applied
 func (c context) AfterApply(update updater.Update) error {
+	if err := c.stop(); err != nil {
+		c.log.Warningf("Error trying to stop: %s", err)
+	}
+
 	if err := c.start(10*time.Second, time.Second); err != nil {
 		c.log.Warningf("Error trying to start the app: %s", err)
 	}

--- a/keybase/platform_linux.go
+++ b/keybase/platform_linux.go
@@ -92,10 +92,6 @@ func (c context) PausedPrompt() bool {
 	return false
 }
 
-func (c context) beforeApply(update updater.Update) error {
-	return nil
-}
-
 func (c context) Apply(update updater.Update, options updater.UpdateOptions, tmpDir string) error {
 	return nil
 }

--- a/keybase/platform_windows.go
+++ b/keybase/platform_windows.go
@@ -298,10 +298,6 @@ func (c context) PausedPrompt() bool {
 	return false
 }
 
-func (c context) beforeApply(update updater.Update) error {
-	return nil
-}
-
 func (c context) Apply(update updater.Update, options updater.UpdateOptions, tmpDir string) error {
 	if update.Asset == nil || update.Asset.LocalPath == "" {
 		return fmt.Errorf("No asset")


### PR DESCRIPTION
We made a change (merged on Friday) where we do (1) stop, (2) apply update, and (3) start. This change hasn't made to public build yet.

I feel like there is a failure mode in this scenario I want to avoid, which is a bug in stop causing the updater to be terminated. This would leave the app orphaned and prevent updates.

I think it would be safer to instead, apply the update first and then stop/start.