### PR TITLE
Use valid source path when falling back to privileged install

### DIFF
--- a/keybase/platform_darwin.go
+++ b/keybase/platform_darwin.go
@@ -288,7 +288,16 @@ func (c context) Apply(update updater.Update, options updater.UpdateOptions, tmp
 	case *os.LinkError:
 		if err.Op == "rename" && err.Old == "/Applications/Keybase.app" {
 			c.log.Infof("The error was a problem renaming (moving) the app, let's trying installing the app via keybase install --components=app which has more privileges")
-			_, installErr := command.Exec(c.config.keybasePath(), []string{"install", "--components=app", fmt.Sprintf("--source-path=%s", localPath)}, 20*time.Second, c.log)
+
+			// Unzip and get source path
+			unzipPath, err := util.UnzipPath(localPath, c.log)
+			defer util.RemoveFileAtPath(unzipPath)
+			if err != nil {
+				return err
+			}
+			sourcePath := filepath.Join(unzipPath, filepath.Base(destinationPath))
+
+			_, installErr := command.Exec(c.config.keybasePath(), []string{"install", "--components=app", fmt.Sprintf("--source-path=%s", sourcePath)}, time.Minute, c.log)
 			if installErr != nil {
 				c.log.Errorf("Error trying to install the app (privileged): %s", installErr)
 				return installErr

--- a/updater.go
+++ b/updater.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Version is the updater version
-const Version = "0.2.9"
+const Version = "0.2.10"
 
 // Updater knows how to find and apply updates
 type Updater struct {

--- a/util/unzip.go
+++ b/util/unzip.go
@@ -42,6 +42,16 @@ func UnzipOver(sourcePath string, path string, destinationPath string, check fun
 	return MoveFile(contentPath, destinationPath, tmpDir, log)
 }
 
+// UnzipPath unzips and returns path to unzipped directory
+func UnzipPath(sourcePath string, log Log) (string, error) {
+	unzipPath := fmt.Sprintf("%s.unzipped", sourcePath)
+	err := unzipOver(sourcePath, unzipPath, log)
+	if err != nil {
+		return "", err
+	}
+	return unzipPath, nil
+}
+
 func unzipOver(sourcePath string, destinationPath string, log Log) error {
 	if destinationPath == "" {
 		return fmt.Errorf("Invalid destination %q", destinationPath)


### PR DESCRIPTION
In the case of privileged install (people who run Keybase not as the user that installed it), I was using the wrong source path (Keybase.zip instead of unzipped Keybase.app).

This is pretty rare scenario, we didn't support it until recently, and so now this actually makes it work after all.