### PR TITLE
Windows: there seems to be a /norestart flag after all

### DIFF
--- a/keybase/platform_windows.go
+++ b/keybase/platform_windows.go
@@ -305,7 +305,7 @@ func (c context) Apply(update updater.Update, options updater.UpdateOptions, tmp
 	var args []string
 	auto, _ := c.config.GetUpdateAuto()
 	if auto && !c.config.GetUpdateAutoOverride() {
-		args = append(args, "/quiet")
+		args = append(args, "/quiet", "/norestart")
 	}
 	_, err := command.Exec(update.Asset.LocalPath, args, time.Hour, c.log)
 	return err

--- a/updater.go
+++ b/updater.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Version is the updater version
-const Version = "0.2.10"
+const Version = "0.2.11"
 
 // Updater knows how to find and apply updates
 type Updater struct {


### PR DESCRIPTION
After so much struggling, somehow today a few seconds' googling revealed [this flag](http://windows-installer-xml-wix-toolset.687559.n2.nabble.com/Running-Burn-driven-installer-in-quiet-mode-command-line-parameters-td5913001.html#a5913628), so let's try it.

I've already built a pair of installers and tested the upgrade - can't repro the reboot case, but it's worth including in case it helps.

cc @chrisnojima 