### PR TITLE
Prompt for apply

### DIFF
--- a/keybase/context.go
+++ b/keybase/context.go
@@ -121,10 +121,8 @@ func (c context) BeforeApply(update updater.Update) error {
 	if err != nil {
 		c.log.Warningf("Error trying to check in use: %s", err)
 	}
-	if inUse {
-		if cancel := c.PausedPrompt(); cancel {
-			return fmt.Errorf("Canceled by user from paused prompt")
-		}
+	if cancel := c.PausedPrompt(inUse); cancel {
+		return fmt.Errorf("Canceled by user from paused prompt")
 	}
 	return nil
 }

--- a/keybase/platform_darwin.go
+++ b/keybase/platform_darwin.go
@@ -111,15 +111,16 @@ func (c context) UpdatePrompt(update updater.Update, options updater.UpdateOptio
 	return c.updatePrompt(promptProgram, update, options, promptOptions, time.Hour)
 }
 
-// PausedPrompt is called when the we can't update cause the app is in use.
-// We return true if the use wants to cancel the update.
-func (c context) PausedPrompt() bool {
+// PausedPrompt is called when want to apply the update.
+// If inUse is true, then we should warn the user about KBFS mount changing.
+// We return true to apply the update, otherwise cancel.
+func (c context) PausedPrompt(inUse bool) bool {
 	promptProgram, err := c.config.promptProgram()
 	if err != nil {
 		c.log.Warningf("Error trying to get prompt path: %s", err)
 		return false
 	}
-	cancelUpdate, err := c.pausedPrompt(promptProgram, 5*time.Minute)
+	cancelUpdate, err := c.pausedPrompt(promptProgram, inUse, 5*time.Minute)
 	if err != nil {
 		c.log.Warningf("Error in paused prompt: %s", err)
 		return false

--- a/updater.go
+++ b/updater.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Version is the updater version
-const Version = "0.2.12"
+const Version = "0.2.13"
 
 // Updater knows how to find and apply updates
 type Updater struct {


### PR DESCRIPTION
Always prompt to apply. If in use, then use the previous prompt.

Otherwise show an apply prompt:
![2017-07-31 at 2 31 pm](https://user-images.githubusercontent.com/2669/28799574-02d0855e-75fe-11e7-93df-7bd0ab4fa0f7.png)

