### PR TITLE
real Windows arch

### DIFF
--- a/keybase/config.go
+++ b/keybase/config.go
@@ -211,11 +211,12 @@ func (c *config) SetInstallID(installID string) error {
 func (c config) updaterOptions() updater.UpdateOptions {
 	version := c.keybaseVersion()
 	osVersion := c.osVersion()
+	osArch := c.osArch()
 
 	return updater.UpdateOptions{
 		Version:         version,
 		Platform:        runtime.GOOS,
-		Arch:            runtime.GOARCH,
+		Arch:            osArch,
 		DestinationPath: c.destinationPath(),
 		Env:             "prod",
 		OSVersion:       osVersion,

--- a/keybase/config_test.go
+++ b/keybase/config_test.go
@@ -70,7 +70,7 @@ func TestConfig(t *testing.T) {
 		DestinationPath: options.DestinationPath,
 		Channel:         "",
 		Env:             "prod",
-		Arch:            runtime.GOARCH,
+		Arch:            cfg.osArch(),
 		Force:           false,
 		OSVersion:       cfg.osVersion(),
 		UpdaterVersion:  updater.Version,

--- a/keybase/platform_darwin.go
+++ b/keybase/platform_darwin.go
@@ -4,8 +4,10 @@
 package keybase
 
 import (
+	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/user"
 	"path/filepath"
 	"runtime"
@@ -96,9 +98,15 @@ func (c config) osVersion() string {
 	return strings.TrimSpace(result.Stdout.String())
 }
 
-// TODO: this only tells us the compile time arch
 func (c config) osArch() string {
-	return runtime.GOARCH
+	cmd := exec.Command("uname", "-m")
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	err := cmd.Run()
+	if err != nil {
+		return runtime.GOARCH
+	}
+	return buf.String()
 }
 
 func (c config) promptProgram() (command.Program, error) {

--- a/keybase/platform_darwin.go
+++ b/keybase/platform_darwin.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -93,6 +94,11 @@ func (c config) osVersion() string {
 		return ""
 	}
 	return strings.TrimSpace(result.Stdout.String())
+}
+
+// TODO: this only tells us the compile time arch
+func (c config) osArch() string {
+	return runtime.GOARCH
 }
 
 func (c config) promptProgram() (command.Program, error) {

--- a/keybase/platform_linux.go
+++ b/keybase/platform_linux.go
@@ -4,8 +4,10 @@
 package keybase
 
 import (
+	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/user"
 	"path/filepath"
 	"runtime"
@@ -67,9 +69,15 @@ func (c config) osVersion() string {
 	return strings.TrimSpace(result.Stdout.String())
 }
 
-// TODO: this only tells us the compile time arch
 func (c config) osArch() string {
-	return runtime.GOARCH
+	cmd := exec.Command("uname", "-m")
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	err := cmd.Run()
+	if err != nil {
+		return runtime.GOARCH
+	}
+	return buf.String()
 }
 
 func (c config) promptProgram() (command.Program, error) {

--- a/keybase/platform_linux.go
+++ b/keybase/platform_linux.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -64,6 +65,11 @@ func (c config) osVersion() string {
 		return ""
 	}
 	return strings.TrimSpace(result.Stdout.String())
+}
+
+// TODO: this only tells us the compile time arch
+func (c config) osArch() string {
+	return runtime.GOARCH
 }
 
 func (c config) promptProgram() (command.Program, error) {

--- a/keybase/platform_windows.go
+++ b/keybase/platform_windows.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -134,7 +135,7 @@ func (c config) osArch() string {
 
 func (c config) notifyProgram() string {
 	// No notify program for Windows
-	return ""
+	return runtime.GOARCH
 }
 
 func (c *context) BeforeUpdatePrompt(update updater.Update, options updater.UpdateOptions) error {

--- a/keybase/platform_windows.go
+++ b/keybase/platform_windows.go
@@ -114,6 +114,24 @@ func (c config) osVersion() string {
 	return strings.TrimSpace(result.Stdout.String())
 }
 
+func (c config) osArch() string {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `Hardware\Description\System\CentralProcessor\0`, registry.QUERY_VALUE)
+	if err != nil {
+		return err.Error()
+	}
+	defer k.Close()
+
+	s, _, err := k.GetStringValue("Identifier")
+	if err != nil {
+		return err.Error()
+	}
+	words := strings.Fields(s)
+	if len(words) < 1 {
+		return "empty"
+	}
+	return words[0]
+}
+
 func (c config) notifyProgram() string {
 	// No notify program for Windows
 	return ""


### PR DESCRIPTION
Turns out we were just sending the arch used for building the binary, which doesn't seem useful. @jzila suggests we may want it still, and to use a new field for the actual user's arch. I think we could worry about that later. @maxtaco ?
@keybase/updater-hackers 