### PR TITLE
osx: stop the redirector before an upgrade

### DIFF
--- a/keybase/platform_darwin.go
+++ b/keybase/platform_darwin.go
@@ -184,7 +184,7 @@ func (c context) stop() error {
 	}
 
 	// Stop the redirector so it can be upgraded for all users.
-	_, redirectorErr := command.Exec(c.config.keybasePath(), []string{"uninstall", "--components=redirector", fmt.Sprintf("--source-path=%s", sourcePath)}, time.Minute, c.log)
+	_, redirectorErr := command.Exec(c.config.keybasePath(), []string{"uninstall", "--components=redirector"}, time.Minute, c.log)
 	if redirectorErr != nil {
 		c.log.Warningf("Error stopping the redirector: %s", redirectorErr)
 	}

--- a/keybase/platform_darwin.go
+++ b/keybase/platform_darwin.go
@@ -183,6 +183,12 @@ func (c context) stop() error {
 		c.log.Warningf("Error requesting app exit: %s", appExitErr)
 	}
 
+	// Stop the redirector so it can be upgraded for all users.
+	_, redirectorErr := command.Exec(c.config.keybasePath(), []string{"uninstall", "--components=redirector", fmt.Sprintf("--source-path=%s", sourcePath)}, time.Minute, c.log)
+	if redirectorErr != nil {
+		c.log.Warningf("Error stopping the redirector: %s", redirectorErr)
+	}
+
 	// Stop services
 	servicesExitResult, servicesExitErr := command.Exec(c.config.keybasePath(), []string{"ctl", "stop", "--include=service,kbfs"}, 30*time.Second, c.log)
 	c.log.Infof("Stop output: %s", servicesExitResult.CombinedOutput())


### PR DESCRIPTION
(Oops I accidentally merged #146 early, then reverted it.  This is a re-make of #146, to be merged later.  Code already reviewed.)

Note that this shouldn't be merged until keybase/client#10648 is merged into client master. But it's good for review now.

Issue: KBFS-2787

