### PR TITLE
Revert "listen for inactive gui for 3 timeouts"

### DIFF
--- a/keybase/platform_darwin.go
+++ b/keybase/platform_darwin.go
@@ -149,11 +149,6 @@ func (c context) PausedPrompt() bool {
 	return cancelUpdate
 }
 
-func (c context) GetAppStatePath() string {
-	home, _ := Dir("keybase")
-	return filepath.Join(home, "app-state.json")
-}
-
 const serviceInBundlePath = "/Contents/SharedSupport/bin/keybase"
 const kbfsInBundlePath = "/Contents/SharedSupport/bin/kbfs"
 

--- a/keybase/platform_linux.go
+++ b/keybase/platform_linux.go
@@ -118,8 +118,3 @@ func (c context) Apply(update updater.Update, options updater.UpdateOptions, tmp
 func (c context) AfterApply(update updater.Update) error {
 	return nil
 }
-
-func (c context) GetAppStatePath() string {
-	home, _ := Dir("keybase")
-	return filepath.Join(home, "app-state.json")
-}

--- a/keybase/platform_windows.go
+++ b/keybase/platform_windows.go
@@ -30,14 +30,10 @@ type guid struct {
 	Data4 [8]byte
 }
 
+// FOLDERID_LocalAppData
+// F1B32785-6FBA-4FCF-9D55-7B8E7F157091
 var (
-	// FOLDERID_LocalAppData
-	// F1B32785-6FBA-4FCF-9D55-7B8E7F157091
 	folderIDLocalAppData = guid{0xF1B32785, 0x6FBA, 0x4FCF, [8]byte{0x9D, 0x55, 0x7B, 0x8E, 0x7F, 0x15, 0x70, 0x91}}
-
-	// FOLDERID_RoamingAppData
-	// {3EB685DB-65F9-4CF6-A03A-E3EF65729F3D}
-	folderIDRoamingAppData = guid{0x3EB685DB, 0x65F9, 0x4CF6, [8]byte{0xA0, 0x3A, 0xE3, 0xEF, 0x65, 0x72, 0x9F, 0x3D}}
 )
 
 var (
@@ -74,10 +70,6 @@ func getDataDir(id guid) (string, error) {
 
 func localDataDir() (string, error) {
 	return getDataDir(folderIDLocalAppData)
-}
-
-func roamingDataDir() (string, error) {
-	return getDataDir(folderIDRoamingAppData)
 }
 
 func (c config) destinationPath() string {
@@ -246,11 +238,4 @@ func (c context) Apply(update updater.Update, options updater.UpdateOptions, tmp
 
 func (c context) AfterApply(update updater.Update) error {
 	return nil
-}
-
-// app-state.json is written in the roaming settings directory, which
-// seems to be where Electron chooses
-func (c context) GetAppStatePath() string {
-	roamingDir, _ := roamingDataDir()
-	return filepath.Join(roamingDir, "Keybase", "app-state.json")
 }

--- a/update_checker_test.go
+++ b/update_checker_test.go
@@ -81,10 +81,6 @@ func (u testUpdateCheckUI) ReportError(_ error, _ *Update, _ UpdateOptions) {}
 
 func (u testUpdateCheckUI) ReportSuccess(_ *Update, _ UpdateOptions) {}
 
-func (c testUpdateCheckUI) GetAppStatePath() string {
-	return ""
-}
-
 func TestUpdateCheckerError(t *testing.T) {
 	testServer := testServerForUpdateFile(t, testZipPath)
 	defer testServer.Close()

--- a/updater.go
+++ b/updater.go
@@ -4,7 +4,6 @@
 package updater
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,7 +21,6 @@ type Updater struct {
 	source UpdateSource
 	config Config
 	log    Log
-	guiBusyCount int
 }
 
 // UpdateSource defines where the updater can find updates
@@ -47,7 +45,6 @@ type Context interface {
 	ReportAction(action UpdateAction, update *Update, options UpdateOptions)
 	ReportSuccess(update *Update, options UpdateOptions)
 	AfterUpdateCheck(update *Update)
-	GetAppStatePath() string
 }
 
 // Config defines configuration for the Updater
@@ -232,14 +229,6 @@ func (u *Updater) promptForUpdateAction(ctx Context, update Update, options Upda
 	autoOverride := u.config.GetUpdateAutoOverride()
 	u.log.Debugf("Auto update: %s (set=%s autoOverride=%s)", strconv.FormatBool(auto), strconv.FormatBool(autoSet), strconv.FormatBool(autoOverride))
 	if auto && !autoOverride {
-		isActive, err := u.checkUserActive(ctx)
-		if isActive {
-			err =  fmt.Errorf("GUI is active, try later")
-		} 
-		if err != nil {
-			return UpdateActionError, err
-		}
-		u.guiBusyCount = 0
 		return UpdateActionAuto, nil
 	}
 
@@ -265,37 +254,6 @@ func (u *Updater) promptForUpdateAction(ctx Context, update Update, options Upda
 	}
 
 	return updatePromptResponse.Action, nil
-}
-
-type guiAppState struct {
-    IsUserActive   bool      `json:"isUserActive"`
-}
-
-func (u *Updater) checkUserActive(ctx Context) (bool, error) {
-
-	if u.guiBusyCount >= 3 {
-		u.log.Warningf("Waited for GUI %d times - ignoring busy", u.guiBusyCount)
-		return false, nil
-	}
-
-	// Read app-state.json, written by the GUI
-	rawState, err := util.ReadFile(ctx.GetAppStatePath())
-	if err != nil {
-		u.log.Warningf("Error reading GUI state - proceeding", err)
-		return false, nil
-	}
-
-    guistate := guiAppState{}
-	err = json.Unmarshal(rawState, &guistate)
-	if err != nil {
-		u.log.Warningf("Error parsing GUI state - proceeding", err)
-		return false, nil
-	}
-	if guistate.IsUserActive {
-		u.guiBusyCount++
-	}
-	
-	return guistate.IsUserActive, nil
 }
 
 func report(ctx Context, err error, update *Update, options UpdateOptions) {


### PR DESCRIPTION
@keybase/react-hackers CC @chrisnojima 

Reverts keybase/go-updater#151

This breaks `keybase update check` from working on macOS if the GUI's been active recently.  But more importantly, I don't think we intended to ship this feature yet, because the rest of the updater work isn't done.