### PR TITLE
Skip the check for idle GUI when updating due to check command

### DIFF
--- a/keybase/context.go
+++ b/keybase/context.go
@@ -40,6 +40,8 @@ type context struct {
 	config Config
 	// log is the logger
 	log Log
+	// isCheckCommand is whether the updater is being invoked with the check command
+	isCheckCommand bool
 }
 
 // endpoints define all the url locations for reporting, etc
@@ -65,8 +67,14 @@ func newContext(cfg Config, log Log) *context {
 	return &ctx
 }
 
+func newContextCheckCmd(cfg Config, log Log, isCheckCommand bool) *context {
+	ctx := newContext(cfg, log)
+	ctx.isCheckCommand = isCheckCommand
+	return ctx
+}
+
 // NewUpdaterContext returns an updater context for Keybase
-func NewUpdaterContext(appName string, pathToKeybase string, log Log) (updater.Context, *updater.Updater) {
+func NewUpdaterContext(appName string, pathToKeybase string, log Log, isCheck bool) (updater.Context, *updater.Updater) {
 	cfg, err := newConfig(appName, pathToKeybase, log)
 	if err != nil {
 		log.Warningf("Error loading config for context: %s", err)
@@ -88,7 +96,7 @@ func NewUpdaterContext(appName string, pathToKeybase string, log Log) (updater.C
 	// keybase update check
 
 	upd := updater.NewUpdater(src, cfg, log)
-	return newContext(cfg, log), upd
+	return newContextCheckCmd(cfg, log, isCheck), upd
 }
 
 // UpdateOptions returns update options

--- a/keybase/platform_darwin.go
+++ b/keybase/platform_darwin.go
@@ -154,6 +154,11 @@ func (c context) GetAppStatePath() string {
 	return filepath.Join(home, "app-state.json")
 }
 
+
+func (c context) IsCheckCommand() bool {
+	return c.isCheckCommand
+}
+
 const serviceInBundlePath = "/Contents/SharedSupport/bin/keybase"
 const kbfsInBundlePath = "/Contents/SharedSupport/bin/kbfs"
 

--- a/keybase/platform_linux.go
+++ b/keybase/platform_linux.go
@@ -123,3 +123,7 @@ func (c context) GetAppStatePath() string {
 	home, _ := Dir("keybase")
 	return filepath.Join(home, "app-state.json")
 }
+
+func (c context) IsCheckCommand() bool {
+	return c.isCheckCommand
+}

--- a/keybase/platform_windows.go
+++ b/keybase/platform_windows.go
@@ -254,3 +254,7 @@ func (c context) GetAppStatePath() string {
 	roamingDir, _ := roamingDataDir()
 	return filepath.Join(roamingDir, "Keybase", "app-state.json")
 }
+
+func (c context) IsCheckCommand() bool {
+	return c.isCheckCommand
+}

--- a/service/main.go
+++ b/service/main.go
@@ -99,12 +99,12 @@ func run(f flags) {
 
 func serviceFromFlags(f flags, ulog logger) *service {
 	ulog.Infof("Updater %s", updater.Version)
-	ctx, upd := keybase.NewUpdaterContext(f.appName, f.pathToKeybase, ulog)
+	ctx, upd := keybase.NewUpdaterContext(f.appName, f.pathToKeybase, ulog, false)
 	return newService(upd, ctx, ulog, f.appName)
 }
 
 func updateCheckFromFlags(f flags, ulog logger) error {
-	ctx, updater := keybase.NewUpdaterContext(f.appName, f.pathToKeybase, ulog)
+	ctx, updater := keybase.NewUpdaterContext(f.appName, f.pathToKeybase, ulog, true)
 	_, err := updater.Update(ctx)
 	return err
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -15,7 +15,7 @@ import (
 var testLog = &logging.Logger{Module: "test"}
 
 func TestService(t *testing.T) {
-	ctx, upd := keybase.NewUpdaterContext("KeybaseTest", "keybase", testLog)
+	ctx, upd := keybase.NewUpdaterContext("KeybaseTest", "keybase", testLog, false)
 	svc := newService(upd, ctx, testLog, "KeybaseTest")
 	assert.NotNil(t, svc)
 

--- a/update_checker_test.go
+++ b/update_checker_test.go
@@ -85,6 +85,10 @@ func (c testUpdateCheckUI) GetAppStatePath() string {
 	return ""
 }
 
+func (c testUpdateCheckUI) IsCheckCommand() bool {
+	return true
+}
+
 func TestUpdateCheckerError(t *testing.T) {
 	testServer := testServerForUpdateFile(t, testZipPath)
 	defer testServer.Close()


### PR DESCRIPTION
Note this PR is against another branch in which the reverted stuff was brought back.
So, I assume this would get merged to zanderz/revert_revert_2018.04.06, and then that would be merged via https://github.com/keybase/go-updater/pull/159 ? IDK, we can discuss.