### PR TITLE
bump version

### DIFF
--- a/updater.go
+++ b/updater.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Version is the updater version
-const Version = "0.2.14"
+const Version = "0.3.00"
 
 // Updater knows how to find and apply updates
 type Updater struct {

--- a/updater.go
+++ b/updater.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Version is the updater version
-const Version = "0.2.13"
+const Version = "0.2.14"
 
 // Updater knows how to find and apply updates
 type Updater struct {

--- a/updater.go
+++ b/updater.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Version is the updater version
-const Version = "0.3.00"
+const Version = "0.3.0"
 
 // Updater knows how to find and apply updates
 type Updater struct {


### PR DESCRIPTION
Seems to have stayed 2.13 since October, though .msi capability on Windows was added in March, etc.