### PR TITLE
Revert "Fix a bug that kept updates from happening as long as GUI was busy"

### DIFF
--- a/updater.go
+++ b/updater.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Version is the updater version
-const Version = "0.3.1"
+const Version = "0.3.0"
 
 // Updater knows how to find and apply updates
 type Updater struct {
@@ -133,8 +133,7 @@ func (u *Updater) update(ctx Context, options UpdateOptions) (*Update, error) {
 	case UpdateActionContinue:
 		// Continue
 	case UpdateActionUIBusy:
-		// Return nil so that AfterUpdateCheck won't exit the service
-		return nil, guiBusyErr(fmt.Errorf("User active, retrying later"))
+		return update, guiBusyErr(fmt.Errorf("User active, retrying later"))
 	}
 
 	// Linux updates don't have assets so it's ok to prompt for update above before
@@ -301,7 +300,6 @@ func (u *Updater) checkUserActive(ctx Context) (bool, error) {
 	}
 	if guistate.IsUserActive {
 		u.guiBusyCount++
-		u.log.Infof("GUI busy on attempt %d", u.guiBusyCount)
 	}
 
 	return guistate.IsUserActive, nil

--- a/updater.go
+++ b/updater.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Version is the updater version
-const Version = "0.3.0"
+const Version = "0.3.2"
 
 // Updater knows how to find and apply updates
 type Updater struct {


### PR DESCRIPTION
@keybase/react-hackers 

Reverts keybase/go-updater#168. Coyne and Nojima saw failed (hanging forever) update attempts this morning, with a hang after the updater killed the old service but before it started a new one.  We haven't established that this PR is responsible, but the timing's suspicious, and it seems like a good idea to get it out of the way while investigating more.