### PR TITLE
Update vendored go-codec to point to master

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -15,8 +15,8 @@
 		{
 			"checksumSHA1": "cYBWzzaRbkBI848bMlYapMC4+Cs=",
 			"path": "github.com/keybase/go-codec/codec",
-			"revision": "109532272978615a09285fb7bd1c0c7ac6be9ac5",
-			"revisionTime": "2018-06-07T22:35:17Z"
+			"revision": "1cf5262595f30a38e4c594385d275b83653a6a89",
+			"revisionTime": "2018-08-20T23:03:36Z"
 		},
 		{
 			"path": "github.com/keybase/go-logging",


### PR DESCRIPTION
No changes, just pointing to the right place now that we updated
go-codec master.