### PR TITLE
add need-update cmd to updater

### DIFF
--- a/service/main.go
+++ b/service/main.go
@@ -84,6 +84,18 @@ func run(f flags) {
 	}
 
 	switch f.command {
+	case "need-update":
+		ctx, updater := keybase.NewUpdaterContext(f.appName, f.pathToKeybase, ulog, true)
+		outOfDate, err := updater.NeedUpdate(ctx)
+		if err != nil {
+			ulog.Error(err)
+			os.Exit(2)
+		}
+		if !outOfDate {
+			fmt.Println("NeedUpdate=false")
+			os.Exit(1)
+		}
+		fmt.Println("NeedUpdate=true")
 	case "check":
 		if err := updateCheckFromFlags(f, ulog); err != nil {
 			ulog.Error(err)

--- a/updater.go
+++ b/updater.go
@@ -231,6 +231,15 @@ func (u *Updater) checkForUpdate(ctx Context, options UpdateOptions) (*Update, e
 	return update, nil
 }
 
+// NeedUpdate returns true if we are out-of-date.
+func (u *Updater) NeedUpdate(ctx Context) (upToDate bool, err error) {
+	update, err := u.checkForUpdate(ctx, ctx.UpdateOptions())
+	if err != nil {
+		return false, err
+	}
+	return update.NeedUpdate, nil
+}
+
 // promptForUpdateAction prompts the user for permission to apply an update
 func (u *Updater) promptForUpdateAction(ctx Context, update Update, options UpdateOptions) (UpdateAction, error) {
 	u.log.Debug("Prompt for update")


### PR DESCRIPTION
This adds a `need-update` subcommand to the updater, so we can call the command to figure out if we should show the "out of date" banner to user.