### PR TITLE
explicitly stop all processes before updating

### DIFF
--- a/keybase/platform_windows.go
+++ b/keybase/platform_windows.go
@@ -300,7 +300,12 @@ func (c *ComponentsChecker) checkRegistryComponents() (result bool) {
 	return result
 }
 
-func (c context) runKeybase(start bool) {
+type KeybaseCommand string
+const (
+  KeybaseCommandStart KeybaseCommand = "watchdog2"
+  KeybaseCommandStop KeybaseCommand = "stop"
+)
+func (c context) runKeybase(cmd KeybaseCommand) {
 	path, err := Dir("Keybase")
 	if err != nil {
 		c.log.Infof("Error getting Keybase directory: %s", err.Error())

--- a/keybase/platform_windows.go
+++ b/keybase/platform_windows.go
@@ -313,7 +313,7 @@ func (c context) runKeybase(cmd KeybaseCommand) {
 	}
 
 	args := []string{filepath.Join(path, "keybase.exe"), "ctl"}
-	if start {
+args = append(args, cmd)
 		args = append(args, "watchdog2")
 	} else {
 		args = append(args, "stop")

--- a/keybase/platform_windows.go
+++ b/keybase/platform_windows.go
@@ -320,7 +320,7 @@ args = append(args, cmd)
 	}
 	_, err = command.Exec(filepath.Join(path, "keybaserq.exe"), args, time.Minute, c.log)
 	if err != nil {
-		c.log.Infof("Error running keybase", err.Error())
+		c.log.Infof("Error %s'ing keybase", cmd, err.Error())
 	}
 }
 

--- a/keybase/platform_windows.go
+++ b/keybase/platform_windows.go
@@ -301,10 +301,12 @@ func (c *ComponentsChecker) checkRegistryComponents() (result bool) {
 }
 
 type KeybaseCommand string
+
 const (
-  KeybaseCommandStart KeybaseCommand = "watchdog2"
-  KeybaseCommandStop KeybaseCommand = "stop"
+	KeybaseCommandStart KeybaseCommand = "watchdog2"
+	KeybaseCommandStop  KeybaseCommand = "stop"
 )
+
 func (c context) runKeybase(cmd KeybaseCommand) {
 	path, err := Dir("Keybase")
 	if err != nil {
@@ -312,12 +314,8 @@ func (c context) runKeybase(cmd KeybaseCommand) {
 		return
 	}
 
-	args := []string{filepath.Join(path, "keybase.exe"), "ctl"}
-args = append(args, cmd)
-		args = append(args, "watchdog2")
-	} else {
-		args = append(args, "stop")
-	}
+	args := []string{filepath.Join(path, "keybase.exe"), "ctl", string(cmd)}
+
 	_, err = command.Exec(filepath.Join(path, "keybaserq.exe"), args, time.Minute, c.log)
 	if err != nil {
 		c.log.Infof("Error %s'ing keybase", cmd, err.Error())
@@ -428,7 +426,7 @@ func (c context) stopKeybaseProcesses() error {
 		return err
 	}
 
-	c.runKeybase(false)
+	c.runKeybase(KeybaseCommandStop)
 	time.Sleep(time.Second)
 
 	// Terminate any executing processes

--- a/updater.go
+++ b/updater.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Version is the updater version
-const Version = "0.3.4"
+const Version = "0.3.5"
 
 // Updater knows how to find and apply updates
 type Updater struct {


### PR DESCRIPTION
@maxtaco I thought about your suggestion (installing .exe files to an intermediate location and switching them separately) and started an implementation, which included these changes, but I realize this might be good enough by itself. I'd like to try shipping this for a few updates.
anyone else I should get a review from?