### PR TITLE
sign updater with correct stuff and update build script

### DIFF
--- a/osx/Updater.xcodeproj/project.pbxproj
+++ b/osx/Updater.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/osx/Updater/Info.plist
+++ b/osx/Updater/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.6</string>
+	<string>1.0.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.6</string>
+	<string>1.0.7</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>

--- a/osx/build.sh
+++ b/osx/build.sh
@@ -8,7 +8,7 @@ cd "$dir"
 app_name="KeybaseUpdater"
 plist="$dir/Updater/Info.plist"
 scheme="Updater"
-code_sign_identity=${CODE_SIGN_IDENTITY:-"Developer ID Application: Keybase, Inc. (99229SGT5K)"}
+code_sign_identity=${CODE_SIGN_IDENTITY:-"9FC3A5BC09FA2EE307C04060C918486411869B65"}
 xcode_configuration="Release"
 install_app_path="/Applications/Keybase.app/Contents/Resources/$app_name.app"
 
@@ -25,12 +25,15 @@ xcodebuild archive -scheme "$scheme" -project "$dir/Updater.xcodeproj" -configur
 echo "Exporting"
 tmp_dir="/tmp"
 tmp_app_path="$tmp_dir/$app_name.app"
+export_dest="$tmp_dir/updater-build"
 rm -rf "$tmp_app_path"
-xcodebuild -exportArchive -archivePath "$archive_path" -exportFormat app -exportPath "$tmp_app_path" | xcpretty -c
+rm -rf "$export_dest"
+xcodebuild -exportArchive -archivePath "$archive_path" -exportOptionsPlist export.plist -exportPath "$export_dest"  | xcpretty -c
+mv "$export_dest/Updater.app" "$tmp_app_path"
 echo "Exported to $tmp_app_path"
 
 echo "Codesigning with $code_sign_identity"
-codesign --verbose --force --deep --sign "$code_sign_identity" "$tmp_app_path"
+codesign --verbose --force --deep --timestamp --options runtime --sign "$code_sign_identity" "$tmp_app_path"
 echo "Checking codesigning..."
 codesign -dvvvv "$tmp_app_path"
 echo " "

--- a/osx/export.plist
+++ b/osx/export.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>


### PR DESCRIPTION
All of this native build stuff was pretty out of date, so update it to work on newer Xcode. Also add the options that allow this to exists in an app bundle that can be notorized.