### PR TITLE
Check if gui is busy after downloading the update

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -4,13 +4,9 @@
 package main
 
 import (
-	"time"
-
 	"github.com/keybase/go-updater"
 	"github.com/keybase/go-updater/util"
 )
-
-const defaultTickDuration = time.Hour
 
 // Log is the logging interface for the service package
 type Log interface {
@@ -44,7 +40,8 @@ func newService(upd *updater.Updater, context updater.Context, log Log, appName 
 
 func (s *service) Start() {
 	if s.updateChecker == nil {
-		tickDuration := util.EnvDuration("KEYBASE_UPDATER_DELAY", defaultTickDuration)
+		tickDuration := util.EnvDuration("KEYBASE_UPDATER_DELAY", updater.DefaultTickDuration)
+		s.updater.SetTickDuration(tickDuration)
 		updateChecker := updater.NewUpdateChecker(s.updater, s.context, tickDuration, s.log)
 		s.updateChecker = &updateChecker
 	}

--- a/update_checker.go
+++ b/update_checker.go
@@ -5,6 +5,8 @@ package updater
 
 import "time"
 
+const DefaultTickDuration = time.Hour
+
 // UpdateChecker runs updates checks every check duration
 type UpdateChecker struct {
 	updater      *Updater

--- a/updater.go
+++ b/updater.go
@@ -312,7 +312,7 @@ type guiAppState struct {
 }
 
 func (u *Updater) checkUserActive(ctx Context) (bool, error) {
-	if time.Duration(u.guiBusyCount)*u.tickDuration >= time.Hour*10 { // Allow the update through after 10 hours
+	if time.Duration(u.guiBusyCount)*u.tickDuration >= time.Hour*6 { // Allow the update through after 6 hours
 		u.log.Warningf("Waited for GUI %d times - ignoring busy", u.guiBusyCount)
 		return false, nil
 	}

--- a/updater_test.go
+++ b/updater_test.go
@@ -484,14 +484,29 @@ func TestUpdaterGuiBusy(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Now put the config file there and make sure the right error is returned
-	err = ioutil.WriteFile(testAppStatePath, []byte("{\"isUserActive\":true}"), 0644)
+	now := time.Now().Unix() * 1000
+	err = ioutil.WriteFile(testAppStatePath, []byte(fmt.Sprintf(`{"isUserActive":true, "changedAtMs":%d}`, now)), 0644)
 	assert.NoError(t, err)
 	defer util.RemoveFileAtPath(testAppStatePath)
 	_, err = upr.Update(ctx)
 	assert.EqualError(t, err, "Update Error (guiBusy): User active, retrying later")
 
+	// If the user was recently active, they are still considered busy.
+	err = ioutil.WriteFile(testAppStatePath, []byte(fmt.Sprintf(`{"isUserActive":false, "changedAtMs":%d}`, now)), 0644)
+	assert.NoError(t, err)
+	_, err = upr.Update(ctx)
+	assert.EqualError(t, err, "Update Error (guiBusy): User active, retrying later")
+
 	// Make sure check command doesn't skip update on active UI
 	ctx.isCheckCommand = true
+	_, err = upr.Update(ctx)
+	assert.NoError(t, err)
+
+	// If the user wasn't recently active, they are not considered busy
+	ctx.isCheckCommand = false
+	later := time.Now().Add(-5*time.Minute).Unix() * 1000
+	err = ioutil.WriteFile(testAppStatePath, []byte(fmt.Sprintf(`{"isUserActive":false, "changedAtMs":%d}`, later)), 0644)
+	assert.NoError(t, err)
 	_, err = upr.Update(ctx)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
Not sure who is best to review here, feel free to un or re assign yoursef. Patch does the following:

- Checks if the gui is busy after downloading the app so we don't restart suddenly if the gui was not active before the download. There is still a chance the app restarts while the user is active but this should make the window much smaller. I've opened a ticket to think about having the gui enter an updating state so the user knows something is happening.
- Modies the ignoring gui busy check, to pass through after 10 hours instead of 3 attempts

cc @chrisnojima 

- [x] after release