### PR TITLE
windows update/quit tweak

### DIFF
--- a/watchdog/watchdog.go
+++ b/watchdog/watchdog.go
@@ -59,6 +59,7 @@ func Watch(programs []Program, restartDelay time.Duration, log Log) error {
 
 func terminateExisting(programs []Program, log Log) {
 	// Terminate any monitored processes
+	// this logic also exists in the updater, so if you want to change it, look there too.
 	ospid := os.Getpid()
 	for _, program := range programs {
 		matcher := process.NewMatcher(program.Path, process.PathEqual, log)


### PR DESCRIPTION
see https://github.com/keybase/client/pull/22023 for a more holistic explanation of these changes

## Before
the watchdog code `ExitAllOnSuccess` (which is used for the service) does not actually exit-all-on-success, rather it exits the current process and the watchdog process, but not any other programs the watchdog is keeping up. In the best case scenario, this results in the updater continuing to run indefinitely after everything else has exited gracefully. 

## After
`ExitAllOnSuccess` exits _all_ on success. This means quitting the app will actually kill all of our processes. When the updater is running, instead of doing a normal quit, it now kills the watchdog first. This way, stopping the service does not trickle up to the watchdog and kill the updater in the middle of its flow. 