### PR TITLE
allow watchdog to handle some pidfile cleanup sometimes

### DIFF
--- a/keybase/report_test.go
+++ b/keybase/report_test.go
@@ -58,7 +58,7 @@ func TestReportBadResponse(t *testing.T) {
 }
 
 func TestReportTimeout(t *testing.T) {
-	server := newServerWithDelay(updateJSONResponse, 5*time.Millisecond)
+	server := newServerWithDelay(updateJSONResponse, 100*time.Millisecond)
 	defer server.Close()
 
 	ctx := testContext(t)


### PR DESCRIPTION
this should only affect windows.

### problem
when the watchdog starts up, it terminates existing running processes for its programs before starting them up. terminating processes in windows is not graceful; they just die in the middle of whatever they were doing. and it seems like sometimes, this can cause an issue with the next service starting up. it thinks the previous iteration is still running because its pidfile was not unlocked during a graceful shutdown. i can't actually dupe this locally, but I've seen it in logs a few times. here's an example `ce58e5e84bb9b6aabcd97d1c` and you can see the unrecoverable error by grepping the service logs for `exiting with error error locking`.

### solution
when starting the watchdog, tell it about the pidfile of the service. this way, if it needs to terminate that process because it's running under another watchdog, it can then also check if it needs to delete the pidfile as well. 

### thoughts
i'm extremely open to suggestions for another way to do this. 