### PR TITLE
handle watchdog race condition

### DIFF
--- a/keybase/report_test.go
+++ b/keybase/report_test.go
@@ -58,7 +58,7 @@ func TestReportBadResponse(t *testing.T) {
 }
 
 func TestReportTimeout(t *testing.T) {
-	server := newServerWithDelay(updateJSONResponse, 5*time.Millisecond)
+	server := newServerWithDelay(updateJSONResponse, 100*time.Millisecond)
 	defer server.Close()
 
 	ctx := testContext(t)

--- a/watchdog/watchdog.go
+++ b/watchdog/watchdog.go
@@ -57,7 +57,34 @@ func Watch(programs []Program, restartDelay time.Duration, log Log) error {
 	return nil
 }
 
+func includesARealProcess(pids []int) bool {
+	for _, p := range pids {
+		if p > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// terminateExisting sends a kill signal to every pid that matches the executables of the
+// programs. It then loops and tries to send these kill signals again to mitigate a race
+// condition where another instance of the watchdog can start another instance of a program
+// while this instance of the watchdog is sending its kill signals.
 func terminateExisting(programs []Program, log Log) {
+	log.Infof("Terminate existing programs")
+	var killedPids []int
+	for i := 1; i <= 3; i++ {
+		killedPids = sendKillToPrograms(programs, log)
+		if !includesARealProcess(killedPids) {
+			log.Infof("none of these programs are running")
+			return
+		}
+		log.Infof("Terminated pids %v", killedPids)
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func sendKillToPrograms(programs []Program, log Log) (killedPids []int) {
 	// Terminate any monitored processes
 	// this logic also exists in the updater, so if you want to change it, look there too.
 	ospid := os.Getpid()
@@ -65,8 +92,10 @@ func terminateExisting(programs []Program, log Log) {
 		matcher := process.NewMatcher(program.Path, process.PathEqual, log)
 		matcher.ExceptPID(ospid)
 		log.Infof("Terminating %s", program.Path)
-		process.TerminateAll(matcher, time.Second, log)
+		pids := process.TerminateAll(matcher, time.Second, log)
+		killedPids = append(killedPids, pids...)
 	}
+	return killedPids
 }
 
 func watchPrograms(programs []Program, delay time.Duration, log Log, exitAll func()) {

--- a/watchdog/watchdog_test.go
+++ b/watchdog/watchdog_test.go
@@ -85,6 +85,53 @@ func TestTerminateBeforeWatch(t *testing.T) {
 	assert.NotEqual(t, pidBefore, pidAfter)
 }
 
+// TestTerminateBeforeWatchRace verifies protection from the following scenario:
+// 		watchdog1 starts up
+// 		watchdog1 looks up existing processes to terminate and sees none
+// 		watchdog2 starts up
+// 		watchdog2 looks up existing processes to terminate and sees watchdog1
+// 		watchdog1 starts PROGRAM
+// 		watchdog1 receives kill signal from watchdog2 and dies
+// 		watchdog2 starts a second PROGRAM
+// 		PROGRAM has a bad time
+// The test doesn't protect us from the race condition generically, rather only when:
+// 		(1) PROGRAM is only started by a watchdog, and
+// 		(2) PROGRAM and watchdog share a path to the same executable. When a
+// 			watchdog looks up existing processes to terminate, it needs to be able
+// 			to find another watchdog.
+func TestTerminateBeforeWatchRace(t *testing.T) {
+	var err error
+	// set up a bunch of iterations of the same program
+	programName := "TestTerminateBeforeWatchRace"
+	otherIterations := make([]Program, 6)
+	for i := 0; i < 6; i++ {
+		otherIterations[i] = procProgram(t, programName, "sleep")
+	}
+	mainProgram := procProgram(t, programName, "sleep")
+	defer util.RemoveFileAtPath(mainProgram.Path)
+	blocker := make(chan struct{})
+	go func() {
+		for _, p := range otherIterations[:3] {
+			_ = exec.Command(p.Path, p.Args...).Start()
+		}
+		blocker <- struct{}{}
+		for _, p := range otherIterations[3:] {
+			_ = exec.Command(p.Path, p.Args...).Start()
+		}
+	}()
+
+	// block until we definitely have something to kill
+	<-blocker
+	err = Watch([]Program{mainProgram}, 10*time.Millisecond, testLog)
+	require.NoError(t, err)
+
+	// Check and make sure there's only one of these processes running
+	matcher := process.NewMatcher(mainProgram.Path, process.PathEqual, testLog)
+	procsAfter, err := process.FindProcesses(matcher, time.Second, time.Millisecond, testLog)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(procsAfter))
+}
+
 func TestExitOnSuccess(t *testing.T) {
 	procProgram := procProgram(t, "testExitOnSuccess", "echo")
 	procProgram.ExitOn = ExitOnSuccess


### PR DESCRIPTION
windows has the unique distinction (i think) of being started by a process (the watchdog) which is not guaranteed by the operating system to be a singleton. as a result, there is an additional risk here that isn't present in the other desktop operating systems. 

if two watchdogs are started at the same time (or even within ~1sec of each other) it's possible to have multiple iterations of the service running at the same time, which causes a bad time. 

this change slows down the process of terminating existing programs to really solidify that the last watchdog started will win. 