### PR TITLE
If Etag match, also check digest if required

### DIFF
--- a/util/http.go
+++ b/util/http.go
@@ -185,6 +185,13 @@ func downloadURL(urlString string, destinationPath string, options DownloadURLOp
 	defer DiscardAndCloseBodyIgnoreError(resp)
 	if resp.StatusCode == http.StatusNotModified {
 		cached = true
+		
+		if options.RequireDigest {
+			if err := CheckDigest(options.Digest, destinationPath); err != nil {
+				return cached, err
+			}
+		}
+		
 		// ETag matched, we already have it
 		log.Infof("Using cached file: %s", destinationPath)
 		return cached, nil


### PR DESCRIPTION
If there is an ETag match, we return before digest check. I don't think this is a security issue but we might as well check the digest if specified.