### PR TITLE
PICNIC-664

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: go
 go:
-  - 1.11.x
-  - 1.12.x
   - 1.13.x
 os:
   - linux

--- a/keybase/platform_darwin.go
+++ b/keybase/platform_darwin.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -49,11 +48,11 @@ func appBundleForPath(path string) string {
 }
 
 func libraryDir() (string, error) {
-	usr, err := user.Current()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(usr.HomeDir, "Library"), nil
+	return filepath.Join(homeDir, "Library"), nil
 }
 
 // Dir returns where to store config

--- a/protocol.go
+++ b/protocol.go
@@ -45,6 +45,14 @@ type Update struct {
 	NeedUpdate  bool       `json:"needUpdate"`
 }
 
+func (u Update) missingAsset() bool {
+	if u.Asset == nil || u.Asset.URL == "" {
+		return true
+	}
+	return false
+
+}
+
 // UpdateOptions are options used to find an update
 type UpdateOptions struct {
 	// Version is the current version of the app

--- a/protocol.go
+++ b/protocol.go
@@ -46,10 +46,7 @@ type Update struct {
 }
 
 func (u Update) missingAsset() bool {
-	if u.Asset == nil || u.Asset.URL == "" {
-		return true
-	}
-	return false
+	return u.Asset == nil || u.Asset.URL == ""
 
 }
 

--- a/service/main.go
+++ b/service/main.go
@@ -91,6 +91,8 @@ func run(f flags) {
 			ulog.Error(err)
 			os.Exit(1)
 		}
+		// Keybase service expects to parse this output as a boolean.
+		// Do not change unless changing in both locations
 		fmt.Println(needUpdate)
 	case "check":
 		if err := updateCheckFromFlags(f, ulog); err != nil {
@@ -104,6 +106,8 @@ func run(f flags) {
 			ulog.Error(err)
 			os.Exit(1)
 		}
+		// Keybase service expects to parse this output as a boolean.
+		// Do not change unless changing in both locations
 		fmt.Println(updateAvailable && updateCached)
 	case "apply-downloaded":
 		ctx, updater := keybase.NewUpdaterContext(f.appName, f.pathToKeybase, ulog, keybase.Check)
@@ -112,6 +116,8 @@ func run(f flags) {
 			ulog.Error(err)
 			os.Exit(1)
 		}
+		// Keybase service expects to parse this output as a boolean.
+		// Do not change unless changing in both locations
 		fmt.Println(applied)
 	case "service", "":
 		svc := serviceFromFlags(f, ulog)

--- a/service/main.go
+++ b/service/main.go
@@ -99,13 +99,12 @@ func run(f flags) {
 		}
 	case "download-latest":
 		ctx, updater := keybase.NewUpdaterContext(f.appName, f.pathToKeybase, ulog, keybase.CheckPassive)
-		fmt.Println("JRY main.go download-latest", f)
-		availableAndDownloaded, err := updater.CheckAndDownload(ctx)
+		updateAvailable, updateCached, err := updater.CheckAndDownload(ctx)
 		if err != nil {
 			ulog.Error(err)
 			os.Exit(1)
 		}
-		fmt.Println(availableAndDownloaded)
+		fmt.Println(updateAvailable && updateCached)
 	case "apply-downloaded":
 		ctx, updater := keybase.NewUpdaterContext(f.appName, f.pathToKeybase, ulog, keybase.Check)
 		if err := updater.ApplyDownloaded(ctx); err != nil {

--- a/service/main.go
+++ b/service/main.go
@@ -107,10 +107,12 @@ func run(f flags) {
 		fmt.Println(updateAvailable && updateCached)
 	case "apply-downloaded":
 		ctx, updater := keybase.NewUpdaterContext(f.appName, f.pathToKeybase, ulog, keybase.Check)
-		if err := updater.ApplyDownloaded(ctx); err != nil {
+		applied, err := updater.ApplyDownloaded(ctx)
+		if err != nil {
 			ulog.Error(err)
 			os.Exit(1)
 		}
+		fmt.Println(applied)
 	case "service", "":
 		svc := serviceFromFlags(f, ulog)
 		svc.Run()

--- a/service/main.go
+++ b/service/main.go
@@ -97,6 +97,21 @@ func run(f flags) {
 			ulog.Error(err)
 			os.Exit(1)
 		}
+	case "download-latest":
+		ctx, updater := keybase.NewUpdaterContext(f.appName, f.pathToKeybase, ulog, keybase.CheckPassive)
+		fmt.Println("JRY main.go download-latest", f)
+		availableAndDownloaded, err := updater.CheckAndDownload(ctx)
+		if err != nil {
+			ulog.Error(err)
+			os.Exit(1)
+		}
+		fmt.Println(availableAndDownloaded)
+	case "apply-downloaded":
+		ctx, updater := keybase.NewUpdaterContext(f.appName, f.pathToKeybase, ulog, keybase.Check)
+		if err := updater.ApplyDownloaded(ctx); err != nil {
+			ulog.Error(err)
+			os.Exit(1)
+		}
 	case "service", "":
 		svc := serviceFromFlags(f, ulog)
 		svc.Run()

--- a/service/main.go
+++ b/service/main.go
@@ -101,14 +101,14 @@ func run(f flags) {
 		}
 	case "download-latest":
 		ctx, updater := keybase.NewUpdaterContext(f.appName, f.pathToKeybase, ulog, keybase.CheckPassive)
-		updateAvailable, updateCached, err := updater.CheckAndDownload(ctx)
+		updateAvailable, _, err := updater.CheckAndDownload(ctx)
 		if err != nil {
 			ulog.Error(err)
 			os.Exit(1)
 		}
 		// Keybase service expects to parse this output as a boolean.
 		// Do not change unless changing in both locations
-		fmt.Println(updateAvailable && updateCached)
+		fmt.Println(updateAvailable)
 	case "apply-downloaded":
 		ctx, updater := keybase.NewUpdaterContext(f.appName, f.pathToKeybase, ulog, keybase.Check)
 		applied, err := updater.ApplyDownloaded(ctx)

--- a/service/main.go
+++ b/service/main.go
@@ -93,6 +93,7 @@ func run(f flags) {
 		}
 		// Keybase service expects to parse this output as a boolean.
 		// Do not change unless changing in both locations
+		// https: //github.com/keybase/client/blob/master/go/client/cmd_update.go
 		fmt.Println(needUpdate)
 	case "check":
 		if err := updateCheckFromFlags(f, ulog); err != nil {
@@ -108,6 +109,7 @@ func run(f flags) {
 		}
 		// Keybase service expects to parse this output as a boolean.
 		// Do not change unless changing in both locations
+		// https: //github.com/keybase/client/blob/master/go/client/cmd_update.go
 		fmt.Println(updateAvailable)
 	case "apply-downloaded":
 		ctx, updater := keybase.NewUpdaterContext(f.appName, f.pathToKeybase, ulog, keybase.Check)
@@ -116,8 +118,6 @@ func run(f flags) {
 			ulog.Error(err)
 			os.Exit(1)
 		}
-		// Keybase service expects to parse this output as a boolean.
-		// Do not change unless changing in both locations
 		fmt.Println(applied)
 	case "service", "":
 		svc := serviceFromFlags(f, ulog)

--- a/updater.go
+++ b/updater.go
@@ -195,9 +195,6 @@ func (u *Updater) ApplyDownloaded(ctx Context) (bool, error) {
 
 	// Only report apply success/failure
 	applied, err := u.applyDownloaded(ctx, update, options)
-	if applied || err != nil {
-		report(ctx, err, update, options)
-	}
 	if err != nil && !applied {
 		report(ctx, err, update, options)
 	}

--- a/updater.go
+++ b/updater.go
@@ -545,6 +545,9 @@ func (u *Updater) Cleanup(tmpDir string) {
 
 // Inspect previously downloaded updates to avoid redownloading
 func (u *Updater) FindDownloadedAsset(assetName string) (matchingAssetPath string, err error) {
+	if assetName == "" {
+		return "", fmt.Errorf("No asset name provided")
+	}
 	parent := os.TempDir()
 
 	if parent == "" || parent == "." {

--- a/updater.go
+++ b/updater.go
@@ -483,7 +483,6 @@ func (u *Updater) tempDir() string {
 }
 
 var tempDirRE = regexp.MustCompile(`^KeybaseUpdater.([ABCDEFGHIJKLMNOPQRSTUVWXYZ234567]{52}|\d{18,})$`)
-var keybaseAssetRE = regexp.MustCompile(`^Keybase(-|_)(.*)$`)
 
 // CleanupPreviousUpdates removes temporary files from previous updates.
 func (u *Updater) CleanupPreviousUpdates() (err error) {

--- a/updater.go
+++ b/updater.go
@@ -195,10 +195,11 @@ func (u *Updater) ApplyDownloaded(ctx Context) (bool, error) {
 
 	// Only report apply success/failure
 	applied, err := u.applyDownloaded(ctx, update, options)
-	if err != nil && !applied {
+	if applied {
 		report(ctx, err, update, options)
 	}
 	if err != nil {
+		report(ctx, err, update, options)
 		return false, err
 	}
 	return applied, nil

--- a/updater.go
+++ b/updater.go
@@ -195,17 +195,16 @@ func (u *Updater) ApplyDownloaded(ctx Context) (bool, error) {
 
 	// Only report apply success/failure
 	applied, err := u.applyDownloaded(ctx, update, options)
+	defer report(ctx, err, update, options)
 	if err != nil {
-		report(ctx, err, update, options)
 		return false, err
 	}
-	report(ctx, err, update, options)
 	return applied, nil
 
 }
 
 // ApplyDownloaded will look for an previously downloaded update and attempt to apply it without prompting.
-// CheckAndDownload must be called first so that we have a download asset avaiable to apply.
+// CheckAndDownload must be called first so that we have a download asset available to apply.
 func (u *Updater) applyDownloaded(ctx Context, update *Update, options UpdateOptions) (applied bool, err error) {
 	if update == nil || !update.NeedUpdate {
 		return false, fmt.Errorf("No previously downloaded update to apply since client is update to date")
@@ -335,11 +334,7 @@ func (u *Updater) CheckAndDownload(ctx Context) (updateAvailable, updateWasDownl
 		return false, false, err
 	}
 
-	if !update.NeedUpdate {
-		return false, false, nil
-	}
-
-	if update.missingAsset() {
+	if !update.NeedUpdate || update.missingAsset() {
 		return false, false, nil
 	}
 

--- a/updater_test.go
+++ b/updater_test.go
@@ -29,21 +29,12 @@ var testZipPath = filepath.Join(os.Getenv("GOPATH"), "src/github.com/keybase/go-
 
 var testAppStatePath = filepath.Join(os.TempDir(), "KBTest_app_state.json")
 
-// shasum -a 256 test/test.zip
 const (
+	// shasum -a 256 test/test.zip
 	validDigest = "54970995e4d02da631e0634162ef66e2663e0eee7d018e816ac48ed6f7811c84"
-)
-
-// keybase sign -d -i test.zip
-const (
-	validSignature = `BEGIN KEYBASE SALTPACK DETACHED SIGNATURE. kXR7VktZdyH7rvq v5wcIkPOwDJ1n11 M8RnkLKQGO2f3Bb fzCeMYz4S6oxLAy Cco4N255JFzv2PX E6WWdobANV4guJI iEE8XJb6uudCX4x QWZfnamVAaZpXuW vdz65rE7oZsLSdW oxMsbBgG9NVpSJy x3CD6LaC9GlZ4IS ofzkHe401mHjr7M M. END KEYBASE SALTPACK DETACHED SIGNATURE.`
-)
-
-const (
-	invalidDigest = "74970995e4d02da631e0634162ef66e2663e0eee7d018e816ac48ed6f7811c84"
-)
-
-const (
+	// keybase sign -d -i test.zip
+	validSignature   = `BEGIN KEYBASE SALTPACK DETACHED SIGNATURE. kXR7VktZdyH7rvq v5wcIkPOwDJ1n11 M8RnkLKQGO2f3Bb fzCeMYz4S6oxLAy Cco4N255JFzv2PX E6WWdobANV4guJI iEE8XJb6uudCX4x QWZfnamVAaZpXuW vdz65rE7oZsLSdW oxMsbBgG9NVpSJy x3CD6LaC9GlZ4IS ofzkHe401mHjr7M M. END KEYBASE SALTPACK DETACHED SIGNATURE.`
+	invalidDigest    = "74970995e4d02da631e0634162ef66e2663e0eee7d018e816ac48ed6f7811c84"
 	invalidSignature = `BEGIN KEYBASE SALTPACK DETACHED SIGNATURE. QXR7VktZdyH7rvq v5wcIkPOwDJ1n11 M8RnkLKQGO2f3Bb fzCeMYz4S6oxLAy Cco4N255JFzv2PX E6WWdobANV4guJI iEE8XJb6uudCX4x QWZfnamVAaZpXuW vdz65rE7oZsLSdW oxMsbBgG9NVpSJy x3CD6LaC9GlZ4IS ofzkHe401mHjr7M M. END KEYBASE SALTPACK DETACHED SIGNATURE.`
 )
 

--- a/updater_test.go
+++ b/updater_test.go
@@ -694,7 +694,10 @@ func TestApplyDownloaded(t *testing.T) {
 func TestFindDownloadedAsset(t *testing.T) {
 	upr, err := newTestUpdater(t)
 	assert.NoError(t, err)
-	defer upr.CleanupPreviousUpdates()
+	defer func() {
+		err = upr.CleanupPreviousUpdates()
+		assert.NoError(t, err)
+	}()
 
 	// 1. empty asset
 	matchingAssetPath, err := upr.FindDownloadedAsset("")
@@ -708,6 +711,7 @@ func TestFindDownloadedAsset(t *testing.T) {
 
 	// 3. asset given -> created KeybaseUpdate. -> directory empty
 	tmpDir, err := util.MakeTempDir("KeybaseUpdater.", 0700)
+	assert.NoError(t, err)
 	require.NoError(t, err)
 
 	matchingAssetPath, err = upr.FindDownloadedAsset("temp")
@@ -718,6 +722,7 @@ func TestFindDownloadedAsset(t *testing.T) {
 
 	// 4. asset given -> created KeybaseUpdate. -> file exists but no match
 	tmpDir, err = util.MakeTempDir("KeybaseUpdater.", 0700)
+	assert.NoError(t, err)
 	tmpFile := filepath.Join(tmpDir, "nottemp")
 	err = ioutil.WriteFile(tmpFile, []byte("Contents of temp file"), 0700)
 	require.NoError(t, err)

--- a/updater_test.go
+++ b/updater_test.go
@@ -604,7 +604,7 @@ func TestApplyDownloaded(t *testing.T) {
 	assert.Nil(t, ctx.updateReported)
 	assert.False(t, ctx.successReported)
 
-	ctx = newTestContext(newDefaultTestUpdateOptions(), upr.config, &UpdatePromptResponse{Action: UpdateActionSnooze, AutoUpdate: true})
+	resetCtxErr()
 
 	// 2. Update missing asset
 	testUpdate.Asset = nil

--- a/updater_test.go
+++ b/updater_test.go
@@ -29,6 +29,26 @@ var testZipPath = filepath.Join(os.Getenv("GOPATH"), "src/github.com/keybase/go-
 
 var testAppStatePath = filepath.Join(os.TempDir(), "KBTest_app_state.json")
 
+// shasum -a 256 test/test.zip
+var validDigest = "54970995e4d02da631e0634162ef66e2663e0eee7d018e816ac48ed6f7811c84"
+
+// keybase sign -d -i test.zip
+var validSignature = `BEGIN KEYBASE SALTPACK DETACHED SIGNATURE. kXR7VktZdyH7rvq v5wcIkPOwDJ1n11 M8RnkLKQGO2f3Bb fzCeMYz4S6oxLAy Cco4N255JFzv2PX E6WWdobANV4guJI iEE8XJb6uudCX4x QWZfnamVAaZpXuW vdz65rE7oZsLSdW oxMsbBgG9NVpSJy x3CD6LaC9GlZ4IS ofzkHe401mHjr7M M. END KEYBASE SALTPACK DETACHED SIGNATURE.`
+
+var invalidDigest = "74970995e4d02da631e0634162ef66e2663e0eee7d018e816ac48ed6f7811c84"
+
+var invalidSignature = `BEGIN KEYBASE SALTPACK DETACHED SIGNATURE. QXR7VktZdyH7rvq v5wcIkPOwDJ1n11 M8RnkLKQGO2f3Bb fzCeMYz4S6oxLAy Cco4N255JFzv2PX E6WWdobANV4guJI iEE8XJb6uudCX4x QWZfnamVAaZpXuW vdz65rE7oZsLSdW oxMsbBgG9NVpSJy x3CD6LaC9GlZ4IS ofzkHe401mHjr7M M. END KEYBASE SALTPACK DETACHED SIGNATURE.`
+
+func makeKeybaseUpdateTempDir(t *testing.T, updater *Updater, testAsset *Asset) (tmpDir string) {
+	// This creates a real KebyaseUpdater.[ID] directory in os.TempDir
+	// Then we download the test zip to this directory from testServer
+	tmpDir, err := util.MakeTempDir("KeybaseUpdater.", 0700)
+	require.NoError(t, err)
+	err = updater.downloadAsset(testAsset, tmpDir, UpdateOptions{})
+	require.NoError(t, err)
+	return tmpDir
+}
+
 func newTestUpdater(t *testing.T) (*Updater, error) {
 	return newTestUpdaterWithServer(t, nil, nil, &testConfig{})
 }
@@ -154,8 +174,8 @@ func newTestUpdate(uri string, needUpdate bool) *Update {
 		update.Asset = &Asset{
 			Name:      "test.zip",
 			URL:       uri,
-			Digest:    "54970995e4d02da631e0634162ef66e2663e0eee7d018e816ac48ed6f7811c84",                                                                                                                                                                                                                       // shasum -a 256 test/test.zip
-			Signature: `BEGIN KEYBASE SALTPACK DETACHED SIGNATURE. kXR7VktZdyH7rvq v5wcIkPOwDJ1n11 M8RnkLKQGO2f3Bb fzCeMYz4S6oxLAy Cco4N255JFzv2PX E6WWdobANV4guJI iEE8XJb6uudCX4x QWZfnamVAaZpXuW vdz65rE7oZsLSdW oxMsbBgG9NVpSJy x3CD6LaC9GlZ4IS ofzkHe401mHjr7M M. END KEYBASE SALTPACK DETACHED SIGNATURE.`, // keybase sign -d -i test.zip
+			Digest:    validDigest,
+			Signature: validSignature,
 		}
 	}
 	return update
@@ -468,6 +488,91 @@ func TestUpdaterNotNeeded(t *testing.T) {
 
 	assert.False(t, ctx.successReported)
 	assert.Equal(t, "deadbeef", upr.config.GetInstallID())
+}
+
+func TestUpdaterCheckAndUpdate(t *testing.T) {
+	testServer := testServerForUpdateFile(t, testZipPath)
+	defer testServer.Close()
+
+	testUpdate := newTestUpdate(testServer.URL, false)
+	upr, err := newTestUpdaterWithServer(t, testServer, testUpdate, &testConfig{})
+	assert.NoError(t, err)
+	defer func() {
+		err = upr.CleanupPreviousUpdates()
+		assert.NoError(t, err)
+	}()
+	ctx := newTestContext(newDefaultTestUpdateOptions(), upr.config, &UpdatePromptResponse{Action: UpdateActionSnooze, AutoUpdate: true})
+
+	// 1.No update from the server
+	// Need update = false
+	// FindDownloadedAsset = false
+	// return updateAvailable = false, updateCached = false
+	updateAvailable, updateCached, err := upr.CheckAndDownload(ctx)
+	assert.NoError(t, err)
+	assert.False(t, updateAvailable)
+	assert.False(t, updateCached)
+	assert.False(t, ctx.successReported)
+	assert.Equal(t, "deadbeef", upr.config.GetInstallID())
+
+	testUpdate.NeedUpdate = true
+
+	// 2. Download asset from URL
+	// Need update = true
+	updateAvailable, updateCached, err = upr.CheckAndDownload(ctx)
+	assert.NoError(t, err)
+	assert.True(t, updateAvailable)
+	assert.True(t, updateCached)
+	assert.False(t, ctx.successReported)
+	assert.Equal(t, "deadbeef", upr.config.GetInstallID())
+
+	// 3.Find existing downloaded assset
+	// Need update = true
+	// FindDownloadedAsset = true
+	// return updateAvailable = true, updateCached = true
+	tmpDir := makeKeybaseUpdateTempDir(t, upr, testUpdate.Asset)
+
+	updateAvailable, updateCached, err = upr.CheckAndDownload(ctx)
+	assert.NoError(t, err)
+	assert.True(t, updateAvailable)
+	assert.True(t, updateCached)
+	assert.False(t, ctx.successReported)
+	assert.Equal(t, "deadbeef", upr.config.GetInstallID())
+
+	util.RemoveFileAtPath(tmpDir)
+
+	// 4.Verify fails b.c. bit flip
+	// Need update = true
+	// FindDownloadedAsset = true
+	// return updateAvailable = true, updateCached = true
+	tmpDir = makeKeybaseUpdateTempDir(t, upr, testUpdate.Asset)
+	testUpdate.Asset.Signature = invalidSignature
+
+	updateAvailable, updateCached, err = upr.CheckAndDownload(ctx)
+	assert.EqualError(t, err, "Update Error (verify): Error verifying signature: failed to read header bytes")
+	assert.False(t, updateAvailable)
+	assert.False(t, updateCached)
+	assert.False(t, ctx.successReported)
+	assert.Equal(t, "deadbeef", upr.config.GetInstallID())
+
+	util.RemoveFileAtPath(tmpDir)
+	testUpdate.Asset.Signature = validSignature
+
+	// 5.Digest fails b.c. bit flip
+	// Need update = true
+	// FindDownloadedAsset = true
+	// return updateAvailable = true, updateCached = true
+	tmpDir = makeKeybaseUpdateTempDir(t, upr, testUpdate.Asset)
+	testUpdate.Asset.Digest = invalidDigest
+
+	updateAvailable, updateCached, err = upr.CheckAndDownload(ctx)
+	assert.EqualError(t, err, fmt.Sprintf("Update Error (verify): Invalid digest: 54970995e4d02da631e0634162ef66e2663e0eee7d018e816ac48ed6f7811c84 != 74970995e4d02da631e0634162ef66e2663e0eee7d018e816ac48ed6f7811c84 (%s)", filepath.Join(tmpDir, testUpdate.Asset.Name)))
+	assert.False(t, updateAvailable)
+	assert.False(t, updateCached)
+	assert.False(t, ctx.successReported)
+	assert.Equal(t, "deadbeef", upr.config.GetInstallID())
+
+	util.RemoveFileAtPath(tmpDir)
+	testUpdate.Asset.Digest = validDigest
 }
 
 func TestUpdaterGuiBusy(t *testing.T) {

--- a/updater_test.go
+++ b/updater_test.go
@@ -598,21 +598,22 @@ func TestApplyDownloaded(t *testing.T) {
 
 	// 1. NeedUpdate = false -> return nil
 	applied, err := upr.ApplyDownloaded(ctx)
-	assert.NoError(t, err)
+	assert.EqualError(t, err, "No previously downloaded update to apply since client is update to date")
 	assert.False(t, applied)
-	assert.Nil(t, ctx.errReported)
+	assert.NotNil(t, ctx.errReported)
 	assert.Nil(t, ctx.updateReported)
 	assert.False(t, ctx.successReported)
 
 	resetCtxErr()
 
 	// 2. Update missing asset
+	testUpdate.NeedUpdate = true
 	testUpdate.Asset = nil
 
 	applied, err = upr.ApplyDownloaded(ctx)
-	assert.NoError(t, err)
+	assert.EqualError(t, err, "Update contained no asset to apply. Update version: 1.0.1")
 	assert.False(t, applied)
-	assert.Nil(t, ctx.errReported)
+	assert.NotNil(t, ctx.errReported)
 	assert.Nil(t, ctx.updateReported)
 	assert.False(t, ctx.successReported)
 
@@ -622,9 +623,9 @@ func TestApplyDownloaded(t *testing.T) {
 	testUpdate.Asset.URL = ""
 
 	applied, err = upr.ApplyDownloaded(ctx)
-	assert.NoError(t, err)
+	assert.EqualError(t, err, "Update contained no asset to apply. Update version: 1.0.1")
 	assert.False(t, applied)
-	assert.Nil(t, ctx.errReported)
+	assert.NotNil(t, ctx.errReported)
 	assert.Nil(t, ctx.updateReported)
 	assert.False(t, ctx.successReported)
 
@@ -633,14 +634,13 @@ func TestApplyDownloaded(t *testing.T) {
 
 	// 3. FindDownloadedAsset = false -> return nil
 	applied, err = upr.ApplyDownloaded(ctx)
-	assert.NoError(t, err)
+	assert.EqualError(t, err, "No downloaded asset found for version: 1.0.1")
 	assert.False(t, applied)
-	assert.Nil(t, ctx.errReported)
+	assert.NotNil(t, ctx.errReported)
 	assert.Nil(t, ctx.updateReported)
 	assert.False(t, ctx.successReported)
 
 	resetCtxErr()
-	testUpdate.NeedUpdate = true
 
 	// 4. FindDownloadedAsset = true -> digest fails
 	tmpDir := makeKeybaseUpdateTempDir(t, upr, testUpdate.Asset)


### PR DESCRIPTION
This PR an extension of https://github.com/keybase/client/pull/21591 to the updater.

#### Intended Flow

1. The GUI will start a 1 hour loop which will make RPC calls to `GetUpdateInfo2`.
2. On macOS and Windows, `GetUpdateInfo2` will call `updater download-latest` to check for a download and cache it. On Linux, `GetUpdateInfo2` will make a request to the `pkg/check` on the API server.
3. `download-latest` on the updater will make a request to `pkg/update` to determine if client needs an update. If the client does, it will first look on disk via `FindDownloadedAsset` to see if we've already cached a keybase update with the same version. If a download does not exist on disk, it will download it from S3. In both cases, once an update exists on disk, it will verify the digest (sha-256) and signature (saltpack) of the asset. This is to maintain the integrity of our cache. If either the digest or signature fail, the asset will be removed from disk. If everything was successful, we print `true` to stdout.
4. If `updater download-lateset` returns true, then the GUI will update KeybaseFM to show that an update is available.
5. The user can then click `Install update`  from KeybaseFM. This will fire a different RPC that will call `updater apply-downloaded`.
6. `apply-downloaded` makes **another** request to `pkg/update` on the API server to ensure that the client still requires an update. If an update is needed then we look on disk for a matching asset. If no asset is found, we return false and attempt to remove any previously downloaded assets. If we did find a matching asset, again we verify the digest (sha-256) and signature (saltpack). If either of these two steps fail, we return false and remove any previously downloaded assets. At this point the digest and signature are valid, so we attempt to apply the update without checking if the GUI is busy because it almost certainly is (given the flow).
7. The only thing that could prevent applying the update immediately is if the user is currently uploading files to KBFS. At this point the updater will present a native prompt to the user indicating this issue. Note: this prompt is not new, it is/has always been a part of the update apply flow.