### PR TITLE
watchdog is safer about processes it kills when ExitAllOnSuccess

### DIFF
--- a/watchdog/watchdog.go
+++ b/watchdog/watchdog.go
@@ -109,21 +109,20 @@ func (p *Program) Run(log Log, shutdownCh chan struct{}) (err error) {
 	return err
 }
 
+type heartbeat struct {
+	name string
+	pid  int
+}
+
 func (w *Watchdog) heartbeatToLog(delay time.Duration) {
 	// wait enough time for the first heartbeat so it's actually useful
 	time.Sleep(1 * time.Minute)
 	for {
-		var heartbeatData []struct {
-			name string
-			pid  int
-		}
+		var heartbeats []heartbeat
 		for _, p := range w.Programs {
-			heartbeatData = append(heartbeatData, struct {
-				name string
-				pid  int
-			}{p.Name, p.runningPid})
+			heartbeats = append(heartbeats, heartbeat{p.Name, p.runningPid})
 		}
-		w.Log.Infof("heartbeating programs: %v", heartbeatData)
+		w.Log.Infof("heartbeating programs: %v", heartbeats)
 		select {
 		case <-w.shutdownCh:
 			w.Log.Infof("watchdog is shutting down, stop heartbeating")


### PR DESCRIPTION
* the biggest change here is around ExitAllOnSuccess. when a program that's ExitAllOnSuccess terminates gracefully, the watchdog will terminate all of its other programs and then itself. Previously, it looked for the other programs to kill by path. Now it keeps track of the current pid of each of its managed processes, and it precisely terminates those (and only those) pids. 
* there's a new test for the race condition ^ which fails on master and succeeds on this branch
* a bunch of changes for logging. the most noticeable will be that logs now display a human-readable `name` of the process. and there's a heartbeat; every hour, the watchdog will log all of the processes and pids that it thinks it's watching. 
