### PR TITLE
Do not hide version detection errors

### DIFF
--- a/keybase/config_test.go
+++ b/keybase/config_test.go
@@ -64,7 +64,7 @@ func TestConfig(t *testing.T) {
 	override = cfg.GetUpdateAutoOverride()
 	assert.True(t, override, "AutoOverride should be set")
 
-	options := cfg.updaterOptions()
+	options, _ := cfg.updaterOptions()
 	t.Logf("Options: %#v", options)
 
 	expectedOptions := updater.UpdateOptions{
@@ -92,7 +92,7 @@ func TestConfig(t *testing.T) {
 	expectedOptions2 := expectedOptions
 	expectedOptions2.IgnoreSnooze = true
 
-	options2 := cfg2.updaterOptions()
+	options2, _ := cfg2.updaterOptions()
 	assert.Equal(t, options2, expectedOptions2)
 
 	auto2, autoSet2 := cfg2.GetUpdateAuto()
@@ -173,6 +173,6 @@ func TestKeybaseVersionInvalid(t *testing.T) {
 	_, filename, _, _ := runtime.Caller(0)
 	testPathToKeybase := filepath.Join(filepath.Dir(filename), "../test/err.sh")
 	cfg, _ := newConfig("KeybaseTest", testPathToKeybase, testLog, false)
-	version := cfg.keybaseVersion()
+	version, _ := cfg.keybaseVersion()
 	assert.Equal(t, "", version)
 }

--- a/keybase/context.go
+++ b/keybase/context.go
@@ -119,7 +119,7 @@ func NewUpdaterContext(appName string, pathToKeybase string, log Log, mode Updat
 }
 
 // UpdateOptions returns update options
-func (c *context) UpdateOptions() updater.UpdateOptions {
+func (c *context) UpdateOptions() (updater.UpdateOptions, error) {
 	return c.config.updaterOptions()
 }
 

--- a/keybase/context_darwin_test.go
+++ b/keybase/context_darwin_test.go
@@ -44,8 +44,8 @@ func (c testConfigPausedPrompt) keybasePath() string {
 	return filepath.Join(filepath.Dir(filename), "../test/keybase-check-in-use-false.sh")
 }
 
-func (c testConfigPausedPrompt) updaterOptions() updater.UpdateOptions {
-	return updater.UpdateOptions{}
+func (c testConfigPausedPrompt) updaterOptions() (updater.UpdateOptions, error) {
+	return updater.UpdateOptions{}, nil
 }
 
 func (c testConfigPausedPrompt) destinationPath() string {

--- a/keybase/context_test.go
+++ b/keybase/context_test.go
@@ -57,7 +57,7 @@ func TestContext(t *testing.T) {
 	ctx := testContext(t)
 
 	// Check options not empty
-	options := ctx.UpdateOptions()
+	options, _ := ctx.UpdateOptions()
 	assert.NotEqual(t, options.Version, "")
 }
 

--- a/keybase/prompt_test.go
+++ b/keybase/prompt_test.go
@@ -25,7 +25,7 @@ func testPromptWithProgram(t *testing.T, promptProgram command.Program, timeout 
 		Description: "Bug fixes",
 	}
 
-	updaterOptions := cfg.updaterOptions()
+	updaterOptions, _ := cfg.updaterOptions()
 
 	promptOptions := updater.UpdatePromptOptions{AutoUpdate: false}
 	return ctx.updatePrompt(promptProgram, update, updaterOptions, promptOptions, timeout)

--- a/update_checker_test.go
+++ b/update_checker_test.go
@@ -71,8 +71,8 @@ func (u testUpdateCheckUI) Verify(update Update) error {
 
 func (u testUpdateCheckUI) AfterUpdateCheck(update *Update) {}
 
-func (u testUpdateCheckUI) UpdateOptions() UpdateOptions {
-	return newDefaultTestUpdateOptions()
+func (u testUpdateCheckUI) UpdateOptions() (UpdateOptions, error) {
+	return newDefaultTestUpdateOptions(), nil
 }
 
 func (u testUpdateCheckUI) ReportAction(_ UpdatePromptResponse, _ *Update, _ UpdateOptions) {}

--- a/updater_test.go
+++ b/updater_test.go
@@ -142,8 +142,8 @@ func (u *testUpdateUI) ReportSuccess(update *Update, options UpdateOptions) {
 
 func (u *testUpdateUI) AfterUpdateCheck(update *Update) {}
 
-func (u testUpdateUI) UpdateOptions() UpdateOptions {
-	return u.options
+func (u testUpdateUI) UpdateOptions() (UpdateOptions, error) {
+	return u.options, nil
 }
 
 func (u testUpdateUI) GetAppStatePath() string {


### PR DESCRIPTION
This should fix [issue keybase/client#24780 "Keybase app on Windows keeps prompting to update"](https://github.com/keybase/client/issues/24780), in that if the updater can't run the version detection properly, it will not assume the version is "" (and so whatever version is available, is an upgrade) and instead error out - hopefully silently.